### PR TITLE
Make resetstats plugin translatable

### DIFF
--- a/scripting/smrpg_resetstats.sp
+++ b/scripting/smrpg_resetstats.sp
@@ -199,19 +199,6 @@ PrintDaysUntilReset(client)
 		DoReset(sReason);
 	}
 	
-	
-	new String:sYearsPhrase[16] = "_dnull"; // special pass-through translation
-	if(iYears > 0)
-		Format(sYearsPhrase, sizeof(sYearsPhrase), "%s", (iYears > 1?"Years":"Year"));
-	
-	new String:sMonthsPhrase[16] = "_dnull";
-	if(iMonths > 0)
-		Format(sMonthsPhrase, sizeof(sMonthsPhrase), "%s", (iMonths > 1?"Months":"Month"));
-	
-	new String:sDaysPhrase[16] = "_dnull";
-	if(iDays > 0)
-		Format(sDaysPhrase, sizeof(sDaysPhrase), "%s", (iDays > 1?"Days":"Day"));
-	
 	// Today is a special case and has it's own phrase.
 	if(iDays == 0)
 	{
@@ -222,13 +209,24 @@ PrintDaysUntilReset(client)
 	}
 	else
 	{
+		new String:sYears[32], String:sMonths[32], String:sDays[32];
+		
 		if(!client)
 		{
-			PrintToServer("daysphrase: %s, %d, monthsphrase: %s, %d, yearsphrase: %s, %d", sDaysPhrase, iDays, sMonthsPhrase, iMonths, sYearsPhrase, iYears);
-			PrintToServer("SM:RPG > %T", "Timed reset in future", LANG_SERVER, sDaysPhrase, iDays, sMonthsPhrase, iMonths, sYearsPhrase, iYears, iNextReset[2], iNextReset[1], iNextReset[0]);
+			TranslateTimespan(LANG_SERVER, sYears, sizeof(sYears), iYears, sMonths, sizeof(sMonths), iMonths, sDays, sizeof(sDays), iDays);
+			PrintToServer("SM:RPG > %T", "Timed reset in future", LANG_SERVER, sDays, sMonths, sYears, iNextReset[2], iNextReset[1], iNextReset[0]);
 		}
 		else
-			Client_PrintToChatAll(false, "{OG}SM:RPG{N} > {G}%t", "Timed reset in future", sDaysPhrase, iDays, sMonthsPhrase, iMonths, sYearsPhrase, iYears, iNextReset[2], iNextReset[1], iNextReset[0]);
+		{
+			for (new i=1;i<=MaxClients;i++)
+			{
+				if (!IsClientInGame(i) || IsFakeClient(i))
+					continue;
+				
+				TranslateTimespan(i, sYears, sizeof(sYears), iYears, sMonths, sizeof(sMonths), iMonths, sDays, sizeof(sDays), iDays);
+				Client_PrintToChat(i, false, "{OG}SM:RPG{N} > {G}%t", "Timed reset in future", sDays, sMonths, sYears, iNextReset[2], iNextReset[1], iNextReset[0]);
+			}
+		}
 	}
 }
 
@@ -317,6 +315,33 @@ DoReset(const String:sReason[])
 	{
 		if(IsClientInGame(i) && !IsFakeClient(i))
 			CreateTimer(1.0, Timer_InformPlayerReset, GetClientSerial(i), TIMER_FLAG_NO_MAPCHANGE);
+	}
+}
+
+TranslateTimespan(client, String:sYears[], iLenYears, iYears, String:sMonths[], iLenMonths, iMonths, String:sDays[], iLenDays, iDays)
+{
+	if(iYears > 0)
+	{
+		if (iYears > 1)
+			Format(sYears, iLenYears, "%T", "Years", client, iYears);
+		else
+			Format(sYears, iLenYears, "%T", "One Year", client);
+	}
+	
+	if(iMonths > 0)
+	{
+		if (iMonths > 1)
+			Format(sMonths, iLenMonths, "%T", "Months", client, iMonths);
+		else
+			Format(sMonths, iLenMonths, "%T", "One Month", client);
+	}
+	
+	if(iDays > 0)
+	{
+		if (iDays > 1)
+			Format(sDays, iLenDays, "%T", "Days", client, iDays);
+		else
+			Format(sDays, iLenDays, "%T", "One Day", client);
 	}
 }
 

--- a/translations/de/smrpg_resetstats.phrases.txt
+++ b/translations/de/smrpg_resetstats.phrases.txt
@@ -2,40 +2,37 @@
 {
   "Admin command resetdatabase"
   {
-    "en"  "The database was wiped. All players are on level 1 again."
+    "de"  "Die Datenbank wurde zurückgesetzt. Alle Spieler sind wieder auf Level 1."
   }
   "Stats reset when levels sum up to"
   {
     // 1: Maximum sum of levels of top 10 players. 
     // 2: Levels remaining until the maximum is reached.
-    "#format"  "{1:d},{2:d}"
-    "en"  "The stats are reset when the levels of the top 10 players sum up to {1}. Still {2} levels left."
+    "de"  "Die Stats werden zurückgesetzt, wenn die Summe der Level der Top 10 Spieler {1} ergibt. Es fehlen noch {2} Level."
   }
   "Warning, your stats were reset on"
   {
     // 1: Day of last reset of the player.
     // 2: Month of the last reset of the player.
     // 3: Year of the last reset of the player.
-    "#format"  "{1:02d},{2:02d},{3:d}"
-    "en"  "{RB}WARNING!{G} Your stats were {RB}reset on {N}{3}-{2}-{1}{G}."
+    "de"  "{RB}WARNUNG!{G} Deine Stats wurden am {N}{1}.{2}.{3} {RB}zurückgesetzt."
   }
   "The whole server got reset, so you're not the only one."
   {
-    "en"  "The whole server got reset, so you're not the only one."
+    "de"  "Der gesamte Server wurde zurückgesetzt - du bist also nicht der Einzige."
   }
   "This is done automatically regularly."
   {
-    "en"  "This is done automatically regularly. Type {N}nextreset{G} to see when it's time again."
+    "de"  "Das passiert regelmäßig automatisch. Schreibe {N}nextreset{G}, um zu sehen, wann es das nächste Mal passiert."
   }
   "Display global reset reason"
   {
     // 1: The reason for the last global reset
-    "#format" "{1:s}"
-    "en"  "Reason: {N}{1}"
+    "de"  "Grund: {N}{1}"
   }
   "Timed reset today"
   {
-    "en"  "The stats are going to be reset today."
+    "de"  "Die Stats werden heute zurückgesetzt."
   }
   "Timed reset in future"
   {
@@ -45,37 +42,33 @@
     // 4: Day of the next reset in the future.
     // 5: Month of the next reset in the future.
     // 6: Year of the next reset in the future.
-    "#format"  "{1:s},{2:s},{3:s},{4:02d},{5:02d},{6:d}"
-    "en"  "The stats are going to be {RB}reset{G} in{3}{2}{1} on {6}-{5}-{4}."
+    "de"  "Die Stats werden in{3}{2}{1} am {4}.{5}.{6} {RB}zurückgesetzt{G}."
   }
   "One Day"
   {
-    "en"  " 1 day"
+    "de"  " 1 Tag"
   }
   "Days"
   {
     // 1: Days until stats are reset.
-    "#format"  "{1:d}"
-    "en"  " {1} days"
+    "de"  " {1} Tagen"
   }
   "One Month"
   {
-    "en"  " 1 month"
+    "de"  " 1 Monat"
   }
   "Months"
   {
     // 1: Months until stats are reset.
-    "#format"  "{1:d}"
-    "en"  " {1} months"
+    "de"  " {1} Monaten"
   }
   "One Year"
   {
-    "en"  " 1 year"
+    "de"  " 1 Jahr"
   }
   "Years"
   {
     // 1: Years until stats are reset.
-    "#format"  "{1:d}"
-    "en"  " {1} years"
+    "de"  " {1} Jahren"
   }
 }

--- a/translations/smrpg_resetstats.phrases.txt
+++ b/translations/smrpg_resetstats.phrases.txt
@@ -7,15 +7,15 @@
   "Stats reset when levels sum up to"
   {
     // 1: Maximum sum of levels of top 10 players. 
-	// 2: Levels remaining until the maximum is reached.
+    // 2: Levels remaining until the maximum is reached.
     "#format"  "{1:d},{2:d}"
     "en"  "The stats are reset when the levels of the top 10 players sum up to {1}. Still {2} levels left."
   }
   "Warning, your stats were reset on"
   {
     // 1: Day of last reset of the player.
-	// 2: Month of the last reset of the player.
-	// 3: Year of the last reset of the player.
+    // 2: Month of the last reset of the player.
+    // 3: Year of the last reset of the player.
     "#format"  "{1:02d},{2:02d},{3:d}"
     "en"  "{RB}WARNING!{G} Your stats were {RB}reset on {N}{3}-{2}-{1}{G}."
   }
@@ -40,19 +40,17 @@
   "Timed reset in future"
   {
     // 1: "Days" or "Day" phrase from below. Days until reset in readable form.
-	// 2: "Months" or "Month" phrase from below. Months until reset in readable form.
-	// 3: "Years" or "Year" phrase from below. Years until reset in readable form.
-	// 4: Day of the next reset in the future.
-	// 5: Month of the next reset in the future.
-	// 6: Year of the next reset in the future.
-    "#format"  "{1:t},{2:t},{3:t},{4:02d},{5:02d},{6:d}"
+    // 2: "Months" or "Month" phrase from below. Months until reset in readable form.
+    // 3: "Years" or "Year" phrase from below. Years until reset in readable form.
+    // 4: Day of the next reset in the future.
+    // 5: Month of the next reset in the future.
+    // 6: Year of the next reset in the future.
+    "#format"  "{1:s},{2:s},{3:s},{4:02d},{5:02d},{6:d}"
     "en"  "The stats are going to be reset in{3}{2}{1} on {6}-{5}-{4}."
   }
-  "Day"
+  "One Day"
   {
-    // 1: Day until stats are reset. (Always 1, technical reasons)
-    "#format"  "{1:d}"
-    "en"  " {1} day"
+    "en"  " 1 day"
   }
   "Days"
   {
@@ -60,11 +58,9 @@
     "#format"  "{1:d}"
     "en"  " {1} days"
   }
-  "Month"
+  "One Month"
   {
-    // 1: Month until stats are reset. (Always 1, technical reasons)
-    "#format"  "{1:d}"
-    "en"  " {1} month"
+    "en"  " 1 month"
   }
   "Months"
   {
@@ -72,23 +68,14 @@
     "#format"  "{1:d}"
     "en"  " {1} months"
   }
-  "Year"
+  "One Year"
   {
-    // 1: Year until stats are reset. (Always 1, technical reasons)
-    "#format"  "{1:d}"
-    "en"  " {1} year"
+    "en"  " 1 year"
   }
   "Years"
   {
     // 1: Years until stats are reset.
     "#format"  "{1:d}"
     "en"  " {1} years"
-  }
-  // Ignore this digit and don't print anything!
-  // This is used in the "Timed reset in future" phrase to print nothing, if e.g. there isn't a year left until the reset.
-  "_dnull"
-  {
-    "#format"  "{1:d}"
-    "en"  ""
   }
 }

--- a/translations/smrpg_resetstats.phrases.txt
+++ b/translations/smrpg_resetstats.phrases.txt
@@ -1,0 +1,94 @@
+"Phrases"
+{
+  "Admin command resetdatabase"
+  {
+    "en"  "The database was wiped. All players are on level 1 again."
+  }
+  "Stats reset when levels sum up to"
+  {
+    // 1: Maximum sum of levels of top 10 players. 
+	// 2: Levels remaining until the maximum is reached.
+    "#format"  "{1:d},{2:d}"
+    "en"  "The stats are reset when the levels of the top 10 players sum up to {1}. Still {2} levels left."
+  }
+  "Warning, your stats were reset on"
+  {
+    // 1: Day of last reset of the player.
+	// 2: Month of the last reset of the player.
+	// 3: Year of the last reset of the player.
+    "#format"  "{1:02d},{2:02d},{3:d}"
+    "en"  "{RB}WARNING!{G} Your stats were {RB}reset on {N}{3}-{2}-{1}{G}."
+  }
+  "The whole server got reset, so you're not the only one."
+  {
+    "en"  "The whole server got reset, so you're not the only one."
+  }
+  "This is done automatically regularly."
+  {
+    "en"  "This is done automatically regularly. Type {N}nextreset{G} to see when it's time again."
+  }
+  "Display global reset reason"
+  {
+    // 1: The reason for the last global reset
+    "#format" "{1:s}"
+    "en"  "Reason: {N}{1}"
+  }
+  "Timed reset today"
+  {
+    "en"  "The stats are going to be reset today."
+  }
+  "Timed reset in future"
+  {
+    // 1: "Days" or "Day" phrase from below. Days until reset in readable form.
+	// 2: "Months" or "Month" phrase from below. Months until reset in readable form.
+	// 3: "Years" or "Year" phrase from below. Years until reset in readable form.
+	// 4: Day of the next reset in the future.
+	// 5: Month of the next reset in the future.
+	// 6: Year of the next reset in the future.
+    "#format"  "{1:t},{2:t},{3:t},{4:02d},{5:02d},{6:d}"
+    "en"  "The stats are going to be reset in{3}{2}{1} on {6}-{5}-{4}."
+  }
+  "Day"
+  {
+    // 1: Day until stats are reset. (Always 1, technical reasons)
+    "#format"  "{1:d}"
+    "en"  " {1} day"
+  }
+  "Days"
+  {
+    // 1: Days until stats are reset.
+    "#format"  "{1:d}"
+    "en"  " {1} days"
+  }
+  "Month"
+  {
+    // 1: Month until stats are reset. (Always 1, technical reasons)
+    "#format"  "{1:d}"
+    "en"  " {1} month"
+  }
+  "Months"
+  {
+    // 1: Months until stats are reset.
+    "#format"  "{1:d}"
+    "en"  " {1} months"
+  }
+  "Year"
+  {
+    // 1: Year until stats are reset. (Always 1, technical reasons)
+    "#format"  "{1:d}"
+    "en"  " {1} year"
+  }
+  "Years"
+  {
+    // 1: Years until stats are reset.
+    "#format"  "{1:d}"
+    "en"  " {1} years"
+  }
+  // Ignore this digit and don't print anything!
+  // This is used in the "Timed reset in future" phrase to print nothing, if e.g. there isn't a year left until the reset.
+  "_dnull"
+  {
+    "#format"  "{1:d}"
+    "en"  ""
+  }
+}


### PR DESCRIPTION
Display localized strings about when the database is going to be reset next.