### PR TITLE
Convert to transitional syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 SM:RPG
 =====
 
-A modular generic RPG plugin for SourceMod 1.6+.
+A modular generic RPG plugin for SourceMod 1.7+.
 
 Based on [CSS:RPG](http://forums.alliedmods.net/showthread.php?t=51039) v1.0.5 by SeLfkiLL.
 

--- a/scripting/include/smrpg.inc
+++ b/scripting/include/smrpg.inc
@@ -8,14 +8,14 @@
  *
  * @return True, if enabled, false otherwise.
  */
-native bool:SMRPG_IsEnabled();
+native bool SMRPG_IsEnabled();
 
 /**
  * Check if bots should not get any effects from the rpg plugin.
  *
  * @return True, if bots should be ignored, false otherwise.
  */
-native bool:SMRPG_IgnoreBots();
+native bool SMRPG_IgnoreBots();
 
 /**
  * Is the server in Free-For-All mode?
@@ -23,15 +23,14 @@ native bool:SMRPG_IgnoreBots();
  *
  * @return True, if teammates are enemies, false otherwise.
  */
-native bool:SMRPG_IsFFAEnabled();
+native bool SMRPG_IsFFAEnabled();
 
 /**
  * Called when SM:RPG is enabled or disabled. (smrpg_enable)
  *
  * @param bEnabled True, if SM:RPG is now enabled, false if it's now disabled.
- * @noreturn
  */
-forward SMRPG_OnEnableStatusChanged(bool:bEnabled);
+forward void SMRPG_OnEnableStatusChanged(bool bEnabled);
 
 #include <smrpg/smrpg_clients>
 #include <smrpg/smrpg_upgrades>
@@ -39,7 +38,7 @@ forward SMRPG_OnEnableStatusChanged(bool:bEnabled);
 #include <smrpg/smrpg_settings>
 #include <smrpg/smrpg_database>
 
-public SharedPlugin:__pl_smrpg = 
+public SharedPlugin __pl_smrpg = 
 {
 	name = "smrpg",
 	file = "smrpg.smx",
@@ -51,7 +50,7 @@ public SharedPlugin:__pl_smrpg =
 };
 
 #if !defined REQUIRE_PLUGIN
-public __pl_smrpg_SetNTVOptional()
+public void __pl_smrpg_SetNTVOptional()
 {
 	MarkNativeAsOptional("SMRPG_IsEnabled");
 	MarkNativeAsOptional("SMRPG_IgnoreBots");

--- a/scripting/include/smrpg/smrpg_clients.inc
+++ b/scripting/include/smrpg/smrpg_clients.inc
@@ -12,7 +12,7 @@
  * @return The client's rpg level (level start at 1)
  * @error Invalid client index
  */
-native SMRPG_GetClientLevel(client);
+native int SMRPG_GetClientLevel(int client);
 
 /**
  * Sets a client's RPG level to another level.
@@ -22,7 +22,7 @@ native SMRPG_GetClientLevel(client);
  * @return True, if the level was set successfully, false if some plugin blocked it in the SMRPG_OnClientLevel forward.
  * @error Invalid client index
  */
-native bool:SMRPG_SetClientLevel(client, level);
+native bool SMRPG_SetClientLevel(int client, int level);
 
 /**
  * Gets a client's current RPG credits.
@@ -31,7 +31,7 @@ native bool:SMRPG_SetClientLevel(client, level);
  * @return The client's rpg credits.
  * @error Invalid client index
  */
-native SMRPG_GetClientCredits(client);
+native int SMRPG_GetClientCredits(int client);
 
 /**
  * Sets a client's RPG credits.
@@ -41,7 +41,7 @@ native SMRPG_GetClientCredits(client);
  * @return True, if the credits were set successfully, false if some plugin blocked it in the SMRPG_OnClientCredits forward.
  * @error Invalid client index
  */
-native bool:SMRPG_SetClientCredits(client, credits);
+native bool SMRPG_SetClientCredits(int client, int credits);
 
 /**
  * Gets a client's current RPG experience.
@@ -50,7 +50,7 @@ native bool:SMRPG_SetClientCredits(client, credits);
  * @return The client's rpg experience
  * @error Invalid client index
  */
-native SMRPG_GetClientExperience(client);
+native int SMRPG_GetClientExperience(int client);
 
 /**
  * Sets a client's RPG experience.
@@ -62,7 +62,7 @@ native SMRPG_GetClientExperience(client);
  * @return True, if the experience were set successfully, false if some plugin blocked it in the SMRPG_OnClientExperience forward.
  * @error Invalid client index
  */
-native bool:SMRPG_SetClientExperience(client, exp);
+native bool SMRPG_SetClientExperience(int client, int exp);
 
 /**
  * Gets the rpg rank of a player.
@@ -72,7 +72,7 @@ native bool:SMRPG_SetClientExperience(client, exp);
  * @return The client's rpg rank or -1 if the rank wasn't fetched yet or for bots.
  * @error Invalid client index
  */
-native SMRPG_GetClientRank(client);
+native int SMRPG_GetClientRank(int client);
 
 /**
  * Get the total number of ranked players in the database.
@@ -80,29 +80,27 @@ native SMRPG_GetClientRank(client);
  *
  * @return Total number of ranked players.
  */
-native SMRPG_GetRankCount();
+native int SMRPG_GetRankCount();
 
 /**
  * Get the top 10 players.
- * The owner handle in the callback is always INVALID_HANDLE just to not leak the database handle :)
+ * The owner handle in the callback is always null just to not leak the database handle :)
  * The query returned is
  *    SELECT name, level, experience, credits FROM ..
  *
  * @param callback    The default threaded sql callback. The query Handle will be in "hndl".
  * @param data        Optional custom data passed to the callback.
- * @noreturn
  */
-native SMRPG_GetTop10Players(SQLTCallback:callback, any:data=0);
+native void SMRPG_GetTop10Players(SQLQueryCallback callback, any data=0);
 
 /**
  * Resets a clients complete rpg stats including all bought upgrades.
  * CANNOT BE UNDONE!
  *
  * @param client				The client index
- * @noreturn
  * @error Invalid client index
  */
-native SMRPG_ResetClientStats(client);
+native void SMRPG_ResetClientStats(int client);
 
 /**
  * Get the time when a client's rpg stats were last reset. Returns the time the player first joined, if his stats were never reset in between.
@@ -111,7 +109,7 @@ native SMRPG_ResetClientStats(client);
  * @return						The unix timestamp when the client was last reset.
  * @error Invalid client index
  */
-native SMRPG_GetClientLastResetTime(client);
+native int SMRPG_GetClientLastResetTime(int client);
 
 /**
  * Get the time when the client was last active on the server.
@@ -120,7 +118,7 @@ native SMRPG_GetClientLastResetTime(client);
  * @return						The unix timestamp when the client was last saved on the server.
  * @error Invalid client index
  */
-native SMRPG_GetClientLastSeenTime(client);
+native int SMRPG_GetClientLastSeenTime(int client);
 
 /**
  * Check if a client is away from keyboard.
@@ -131,7 +129,7 @@ native SMRPG_GetClientLastSeenTime(client);
  * @return	True if player afk, false otherwise.
  * @error Invalid client index
  */
-native bool:SMRPG_IsClientAFK(client);
+native bool SMRPG_IsClientAFK(int client);
 
 /**
  * Check if a client just spawned and hasn't pressed any buttons yet.
@@ -140,7 +138,7 @@ native bool:SMRPG_IsClientAFK(client);
  * @return	True if player just spawned, false otherwise.
  * @error Invalid client index
  */
-native bool:SMRPG_IsClientSpawnProtected(client);
+native bool SMRPG_IsClientSpawnProtected(int client);
 
 /**
  * Called when the core wants a reason string to be translated so it's displayed in the recent added experience panel.
@@ -154,9 +152,8 @@ native bool:SMRPG_IsClientSpawnProtected(client);
  * @param other         Optionally the index of the other client involved in the reason for this experience. -1 if no other entity involved.
  * @param buffer        The buffer to store the translated reason string in.
  * @param maxlen        The maximal length of the translation buffer.
- * @noreturn
  */
-functag public SMRPG_ExpTranslationCb(client, const String:reason[], iExperience, other, String:buffer[], maxlen);
+typedef SMRPG_ExpTranslationCb = function void (int client, const char[] reason, int iExperience, int other, char[] buffer, int maxlen);
 
 /**
  * Adds experience to a client.
@@ -171,7 +168,7 @@ functag public SMRPG_ExpTranslationCb(client, const String:reason[], iExperience
  * @return               True if the experience was added, false otherwise.
  * @error Invalid client index
  */
-native bool:SMRPG_AddClientExperience(client, &exp, const String:reason[], bool:bHideNotice, other=-1, SMRPG_ExpTranslationCb:callback=SMRPG_ExpTranslationCb:INVALID_FUNCTION);
+native bool SMRPG_AddClientExperience(int client, int &exp, const char[] reason, bool bHideNotice, int other=-1, SMRPG_ExpTranslationCb callback=view_as<SMRPG_ExpTranslationCb>(INVALID_FUNCTION));
 
 /**
  * Calculate the amount of experience needed to reach the next level.
@@ -179,15 +176,14 @@ native bool:SMRPG_AddClientExperience(client, &exp, const String:reason[], bool:
  * 
  * @return The amount of experience needed to reach iLevel+1.
  */
-native SMRPG_LevelToExperience(iLevel);
+native int SMRPG_LevelToExperience(int iLevel);
 
 /**
  * Called when a client's upgrade levels were loaded from the database.
  * 
  * @param client         The client who's levels were just loaded.
- * @noreturn
  */
-forward SMRPG_OnClientLoaded(client);
+forward void SMRPG_OnClientLoaded(int client);
 
 /**
  * Called when the level of a client changes.
@@ -198,7 +194,7 @@ forward SMRPG_OnClientLoaded(client);
  * @param newlevel       The new level the client is going to be set to.
  * @return >= Plugin_Handled to block, Plugin_Continue to let it pass.
  */
-forward Action:SMRPG_OnClientLevel(client, oldlevel, newlevel);
+forward Action SMRPG_OnClientLevel(int client, int oldlevel, int newlevel);
 
 /**
  * Called after the level of a client changed.
@@ -206,9 +202,8 @@ forward Action:SMRPG_OnClientLevel(client, oldlevel, newlevel);
  * @param client         The client, who's level has changed.
  * @param oldlevel       The old level of the client.
  * @param newlevel       The new, current level of the client.
- * @noreturn
  */
-forward SMRPG_OnClientLevelPost(client, oldlevel, newlevel);
+forward void SMRPG_OnClientLevelPost(int client, int oldlevel, int newlevel);
 
 /**
  * Called when the experience of a client changes.
@@ -219,7 +214,7 @@ forward SMRPG_OnClientLevelPost(client, oldlevel, newlevel);
  * @param newexp         The new experience the client is going to be set to.
  * @return >= Plugin_Handled to block, Plugin_Continue to let it pass.
  */
-forward Action:SMRPG_OnClientExperience(client, oldexp, newexp);
+forward Action SMRPG_OnClientExperience(int client, int oldexp, int newexp);
 
 /**
  * Called after the experience of a client changed.
@@ -227,9 +222,8 @@ forward Action:SMRPG_OnClientExperience(client, oldexp, newexp);
  * @param client         The client, who's experience has changed.
  * @param oldexp         The old experience of the client.
  * @param newexp         The new, current experience of the client.
- * @noreturn
  */
-forward SMRPG_OnClientExperiencePost(client, oldexp, newexp);
+forward void SMRPG_OnClientExperiencePost(int client, int oldexp, int newexp);
 
 /**
  * Called when the credits of a client changes.
@@ -240,7 +234,7 @@ forward SMRPG_OnClientExperiencePost(client, oldexp, newexp);
  * @param newcredits     The new credits the client is going to be set to.
  * @return >= Plugin_Handled to block, Plugin_Continue to let it pass.
  */
-forward Action:SMRPG_OnClientCredits(client, oldcredits, newcredits);
+forward Action SMRPG_OnClientCredits(int client, int oldcredits, int newcredits);
 
 /**
  * Called after the credits of a client changed.
@@ -248,9 +242,8 @@ forward Action:SMRPG_OnClientCredits(client, oldcredits, newcredits);
  * @param client         The client, who's credits have changed.
  * @param oldcredits     The old credits of the client.
  * @param newcredits     The new, current credits of the client.
- * @noreturn
  */
-forward SMRPG_OnClientCreditsPost(client, oldcredits, newcredits);
+forward void SMRPG_OnClientCreditsPost(int client, int oldcredits, int newcredits);
 
 /**
  * List of default reasons the core plugin adds experience to clients for.
@@ -271,7 +264,7 @@ forward SMRPG_OnClientCreditsPost(client, oldcredits, newcredits);
  * @param other          The other entity which was involved in adding this experience. e.g. the victim which was hurt. -1 if no other particular entity was involved.
  * @return >= Plugin_Handled to block it, Plugin_Continue to pass, Plugin_Changed if you modified iExperience.
  */
-forward Action:SMRPG_OnAddExperience(client, const String:reason[], &iExperience, other);
+forward Action SMRPG_OnAddExperience(int client, const char[] reason, int &iExperience, int other);
 
 /**
  * Called after a client received some experience.
@@ -281,9 +274,8 @@ forward Action:SMRPG_OnAddExperience(client, const String:reason[], &iExperience
  * @param reason         The reason why this client got experience.
  * @param iExperience    The experience to given to the player.
  * @param other          The other entity which was involved in adding this experience. e.g. the victim which was hurt. -1 if no other particular entity was involved.
- * @noreturn
  */
-forward SMRPG_OnAddExperiencePost(client, const String:reason[], iExperience, other);
+forward void SMRPG_OnAddExperiencePost(int client, const char[] reason, int iExperience, int other);
 
 /**
  * Types of experience multipliers that can be set individually per weapon.
@@ -305,7 +297,7 @@ enum WeaponExperienceType {
  *
  * @return The experience multiplier for the selected type for this weapon.
  */
-native Float:SMRPG_GetWeaponExperience(const String:sWeapon[], WeaponExperienceType:type);
+native float SMRPG_GetWeaponExperience(const char[] sWeapon, WeaponExperienceType type);
 
 /**
  * Calculate the ratio of team1:team2.
@@ -314,20 +306,20 @@ native Float:SMRPG_GetWeaponExperience(const String:sWeapon[], WeaponExperienceT
  * @param iTeam          The team index of the player which is about to get experience.
  * @return The teammember amount ratio of iTeam : otherTeam.
  */
-stock Float:SMRPG_TeamRatio(iTeam)
+stock float SMRPG_TeamRatio(int iTeam)
 {
 	if(iTeam <= 1)
 		return 0.0;
 	
-	static Handle:hUseTeamRatio = INVALID_HANDLE;
-	if(hUseTeamRatio == INVALID_HANDLE)
+	static ConVar hUseTeamRatio = null;
+	if(hUseTeamRatio == null)
 		hUseTeamRatio = FindConVar("smrpg_exp_use_teamratio");
 	
 	// Server is configured to ignore team ratio?
-	if(hUseTeamRatio != INVALID_HANDLE && !GetConVarBool(hUseTeamRatio))
+	if(hUseTeamRatio != null && !hUseTeamRatio.BoolValue)
 		return 1.0;
 	
-	new Float:fTeamRatio;
+	float fTeamRatio;
 	
 	if(iTeam == 2)
 		fTeamRatio = float(GetTeamClientCount(2)) / float(GetTeamClientCount(3));

--- a/scripting/include/smrpg/smrpg_database.inc
+++ b/scripting/include/smrpg/smrpg_database.inc
@@ -14,12 +14,10 @@
  * @param bHardReset	Delete all player related information from the database? This will remove all settings the player might have set too.
  * @return True if the stats were reset, false otherwise (database connection problems or smrpg_save_data disabled).
  */
-native bool:SMRPG_ResetAllPlayers(const String:sReason[], bool:bHardReset=false);
+native bool SMRPG_ResetAllPlayers(const char[] sReason, bool bHardReset=false);
 
 /**
  * Flushes the current stats of all players from the cache into the database, making them persistent.
  * This obeys the settings for smrpg_enable and smrpg_save_data.
- *
- * @noreturn
  */
-native SMRPG_FlushDatabase();
+native void SMRPG_FlushDatabase();

--- a/scripting/include/smrpg/smrpg_settings.inc
+++ b/scripting/include/smrpg/smrpg_settings.inc
@@ -13,20 +13,17 @@
  * @param maxlen	The maximum length of the buffer.
  * @return True if the setting existed and was retrieved, false otherwise.
  */
-native bool:SMRPG_GetSetting(const String:sKey[], String:sValue[], maxlen);
+native bool SMRPG_GetSetting(const char[] sKey, char[] sValue, int maxlen);
 
 /**
  * Set a setting variable in the smrpg "settings" table.
  *
  * @param sKey		The name of the setting.
  * @param sValue	The new value of the setting.
- * @noreturn
  */
-native SMRPG_SetSetting(const String:sKey[], String:sValue[]);
+native void SMRPG_SetSetting(const char[] sKey, char[] sValue);
 
 /**
  * Called when the settings were loaded from the database.
- *
- * @noreturn
  */
-forward SMRPG_OnSettingsLoaded();
+forward void SMRPG_OnSettingsLoaded();

--- a/scripting/include/smrpg/smrpg_topmenu.inc
+++ b/scripting/include/smrpg/smrpg_topmenu.inc
@@ -4,6 +4,7 @@
 #define _smrpg_topmenu_included
 
 #include <smrpg>
+#include <topmenus>
 
 /** Category names of default topmenu categories */
 #define RPGMENU_UPGRADES "RPGUpgradesMenu"
@@ -16,22 +17,20 @@
 /**
  * Get the handle to the rpgmenu top menu.
  *
- * @return Handle to the rpgmenu top menu or INVALID_HANDLE if not created yet.
+ * @return Handle to the rpgmenu top menu or null if not created yet.
  */
-native Handle:SMRPG_GetTopMenu();
+native TopMenu SMRPG_GetTopMenu();
 
 /**
  * Called when the rpgmenu is created and 3rd party plugins can grab the Handle or add categories.
  *
  * @param topmenu Handle to the rpgmenu TopMenu.
- * @noreturn
  */
-forward SMRPG_OnRPGMenuCreated(Handle:topmenu);
+forward void SMRPG_OnRPGMenuCreated(TopMenu topmenu);
 
 /**
  * Called when the rpgmenu is ready to have items added. 
  *
  * @param topmenu Handle to the rpgmenu TopMenu.
- * @noreturn
  */
-forward SMRPG_OnRPGMenuReady(Handle:topmenu);
+forward void SMRPG_OnRPGMenuReady(TopMenu topmenu);

--- a/scripting/include/smrpg/smrpg_upgrades.inc
+++ b/scripting/include/smrpg/smrpg_upgrades.inc
@@ -22,9 +22,8 @@ enum UpgradeQueryType
  *
  * @param client         The client, whos upgrade level changed.
  * @param type           The type of the change. (buy or sell)
- * @noreturn
  */
-functag public SMRPG_UpgradeQueryCB(client, UpgradeQueryType:type);
+typedef SMRPG_UpgradeQueryCB = function void (int client, UpgradeQueryType type);
 
 /**
  * Called to check, if an upgrade's effect is currently active on a client.
@@ -35,7 +34,7 @@ functag public SMRPG_UpgradeQueryCB(client, UpgradeQueryType:type);
  * @param client         The client, which should be checked, if the upgrade is currently active on him.
  * @return True, if the upgrade's effect is currently active on the client, false otherwise.
  */
-functag public bool:SMRPG_ActiveQueryCB(client);
+typedef SMRPG_ActiveQueryCB = function bool (int client);
 
 /**
  * Registers a new upgrade to the rpg core.
@@ -66,10 +65,9 @@ functag public bool:SMRPG_ActiveQueryCB(client);
  * @param iAdminFlags       Restrict this upgrade to players with certain flags. See ADMFLAG_* defines. Set to 0 to have it usable by everyone by default.
  * @param querycb           The callback which is called when a client buys / sells this upgrade. Can be used to apply some effects immediately on purchase.
  * @param activecb          The callback which is called to check whether the upgrade currently has some active effect on the client.
- * @noreturn
  * @error Upgrade shortname already exists.
  */
-native SMRPG_RegisterUpgradeType(const String:name[], const String:shortname[], const String:description[], maxlevelbarrier, bool:bDefaultEnable, iDefaultMaxLevel, iDefaultStartCost, iDefaultCostInc, iAdminFlags=0, SMRPG_UpgradeQueryCB:querycb, SMRPG_ActiveQueryCB:activecb);
+native void SMRPG_RegisterUpgradeType(const char[] name, const char[] shortname, const char[] description, int maxlevelbarrier, bool bDefaultEnable, int iDefaultMaxLevel, int iDefaultStartCost, int iDefaultCostInc, int iAdminFlags=0, SMRPG_UpgradeQueryCB querycb, SMRPG_ActiveQueryCB activecb);
 
 /**
  * Unregisters a given upgrade from the core.
@@ -78,10 +76,9 @@ native SMRPG_RegisterUpgradeType(const String:name[], const String:shortname[], 
  * Call this in OnPluginEnd()!
  *
  * @param shortname      The shortname of the upgrade you want to unregister.
- * @noreturn
  * @error Unknown upgrade shortname.
  */
-native SMRPG_UnregisterUpgradeType(const String:shortname[]);
+native void SMRPG_UnregisterUpgradeType(const char[] shortname);
 
 /**
  * Create a convar for the upgrade.
@@ -100,7 +97,7 @@ native SMRPG_UnregisterUpgradeType(const String:shortname[]);
  * @return A handle to the newly created convar. If the convar already exists, a handle to it will still be returned.
  * @error Convar name is blank or is the same as an existing console command.
  */
-native Handle:SMRPG_CreateUpgradeConVar(const String:shortname[], const String:name[], const String:defaultValue[], const String:description[]="", flags=0, bool:hasMin=false, Float:min=0.0, bool:hasMax=false, Float:max=0.0);
+native ConVar SMRPG_CreateUpgradeConVar(const char[] shortname, const char[] name, const char[] defaultValue, const char[] description="", int flags=0, bool hasMin=false, float min=0.0, bool hasMax=false, float max=0.0);
 
 /**
  * Types of translatable information of the upgrade.
@@ -120,9 +117,8 @@ enum TranslationType
  * @param type           The requested TranslationType (name or description).
  * @param translation    The translation buffer.
  * @param maxlen         The maximal length of the buffer.
- * @noreturn
  */
-functag public SMRPG_TranslateUpgradeCB(client, const String:shortname[], TranslationType:type, String:translation[], maxlen);
+typedef SMRPG_TranslateUpgradeCB = function void (int client, const char[] shortname, TranslationType type, char[] translation, int maxlen);
 
 /**
  * Set a translation callback for the named upgrade.
@@ -131,10 +127,9 @@ functag public SMRPG_TranslateUpgradeCB(client, const String:shortname[], Transl
  *
  * @param shortname      The shortname of the upgrade you want to add the translation callback to.
  * @param cb             The callback function to register.
- * @noreturn
  * @error Unknown upgrade shortname.
  */
-native SMRPG_SetUpgradeTranslationCallback(const String:shortname[], SMRPG_TranslateUpgradeCB:cb);
+native void SMRPG_SetUpgradeTranslationCallback(const char[] shortname, SMRPG_TranslateUpgradeCB cb);
 
 /**
  * Called, when another plugin wants to stop the effect of this upgrade via SMRPG_ResetUpgradeEffectOnClient.
@@ -143,9 +138,8 @@ native SMRPG_SetUpgradeTranslationCallback(const String:shortname[], SMRPG_Trans
  * Passive upgrades (like regeneration) don't need to register this callback.
  *
  * @param client         Stop all effects on this client.
- * @noreturn
  */
-functag public SMRPG_ResetEffectCB(client);
+typedef SMRPG_ResetEffectCB = function void (int client);
 
 /**
  * Set a effect reset callback for the named upgrade.
@@ -156,10 +150,9 @@ functag public SMRPG_ResetEffectCB(client);
  *
  * @param shortname      The shortname of the upgrade you want to add the translation callback to.
  * @param cb             The callback function to register.
- * @noreturn
  * @error Unknown upgrade shortname.
  */
-native SMRPG_SetUpgradeResetCallback(const String:shortname[], SMRPG_ResetEffectCB:cb);
+native void SMRPG_SetUpgradeResetCallback(const char[] shortname, SMRPG_ResetEffectCB cb);
 
 /** List of different cosmetical effects */
 enum SMRPG_FX {
@@ -178,10 +171,9 @@ enum SMRPG_FX {
  * @param shortname       The shortname of the upgrade.
  * @param effecttype      What kind of effect does this plugin support? See SMRPG_FX enum.
  * @param bDefaultEnable  Should the upgrade show the effects by default?
- * @noreturn
  * @error Unknown upgrade shortname.
  */
-native SMRPG_SetUpgradeDefaultCosmeticEffect(const String:shortname[], SMRPG_FX:effecttype, bool:bDefaultEnable);
+native void SMRPG_SetUpgradeDefaultCosmeticEffect(const char[] shortname, SMRPG_FX effecttype, bool bDefaultEnable);
 
 /**
  * Returns whether a visual or sound effect should be played for a client.
@@ -192,7 +184,7 @@ native SMRPG_SetUpgradeDefaultCosmeticEffect(const String:shortname[], SMRPG_FX:
  * @return            True if client has that cosmetic type enabled, false otherwise.
  * @error Invalid client index, unknown upgrade shortname.
  */
-native bool:SMRPG_ClientWantsCosmetics(client, const String:shortname[], SMRPG_FX:effecttype);
+native bool SMRPG_ClientWantsCosmetics(int client, const char[] shortname, SMRPG_FX effecttype);
 
 /**
  * Signal other plugins that this upgrade is about to do its effects on a client.
@@ -209,7 +201,7 @@ native bool:SMRPG_ClientWantsCosmetics(client, const String:shortname[], SMRPG_F
  * @return True, if it's ok to run the effect, false if some other plugin doesn't want you to apply the effects.
  * @error Invalid client index, unknown upgrade shortname.
  */
-native bool:SMRPG_RunUpgradeEffect(target, const String:shortname[], issuer=-1);
+native bool SMRPG_RunUpgradeEffect(int target, const char[] shortname, int issuer=-1);
 
 /**
  * Check if an upgrade with that shortname exists.
@@ -217,7 +209,7 @@ native bool:SMRPG_RunUpgradeEffect(target, const String:shortname[], issuer=-1);
  * @param shortname      The shortname of the upgrade.
  * @return True, if there is an upgrade with that shortname registered, false otherwise.
  */
-native bool:SMRPG_UpgradeExists(const String:shortname[]);
+native bool SMRPG_UpgradeExists(const char[] shortname);
 
 /**
  * The maximal length of the full name of an upgrade
@@ -256,10 +248,9 @@ enum UpgradeInfo
  * @param shortname      The shortname of the upgrade you want to know more about.
  * @param upgrade        An buffer array to hold all the upgrade information.
  * @param size           The size of the buffer array.
- * @noreturn
  * @error Unkown upgrade shortname.
  */
-native SMRPG_GetUpgradeInfo(const String:shortname[], upgrade[UpgradeInfo], size=_:UpgradeInfo);
+native void SMRPG_GetUpgradeInfo(const char[] shortname, upgrade[UpgradeInfo], int size=view_as<int>(UpgradeInfo));
 
 /**
  * Ask the plugin controlling an upgrade to remove all active effects from a client.
@@ -268,10 +259,9 @@ native SMRPG_GetUpgradeInfo(const String:shortname[], upgrade[UpgradeInfo], size
  *
  * @param client         The client to stop all effects on.
  * @param shortname      The upgrade shortname, which effects should be stopped on the client.
- * @noreturn
  * @error Invalid client index, unknown upgrade shortname.
  */
-native SMRPG_ResetUpgradeEffectOnClient(client, const String:shortname[]);
+native void SMRPG_ResetUpgradeEffectOnClient(int client, const char[] shortname);
 
 /**
  * Checks if an upgrade's effect is currently active on a client.
@@ -282,7 +272,7 @@ native SMRPG_ResetUpgradeEffectOnClient(client, const String:shortname[]);
  * @return True, if the plugin handling the upgrade said, there is some effect active, false otherwise.
  * @error Invalid client index, unknown upgrade shortname.
  */
-native bool:SMRPG_IsUpgradeActiveOnClient(client, const String:shortname[]);
+native bool SMRPG_IsUpgradeActiveOnClient(int client, const char[] shortname);
 
 /**
  * Checks if a client has access to an upgrade.
@@ -296,7 +286,7 @@ native bool:SMRPG_IsUpgradeActiveOnClient(client, const String:shortname[]);
  * @return True, if the client is allowed to use this upgrade, false otherwise.
  * @error Invalid client index, unknown upgrade shortname.
  */
-native bool:SMRPG_CheckUpgradeAccess(client, const String:shortname[]);
+native bool SMRPG_CheckUpgradeAccess(int client, const char[] shortname);
 
 /**
  * Get the selected level of an upgrade of a client.
@@ -308,7 +298,7 @@ native bool:SMRPG_CheckUpgradeAccess(client, const String:shortname[]);
  * @return The level of the upgrade the client has selected. 0 if he didn't buy it yet or has it disabled.
  * @error Invalid client index, unknown upgrade shortname.
  */
-native SMRPG_GetClientUpgradeLevel(client, const String:shortname[]);
+native int SMRPG_GetClientUpgradeLevel(int client, const char[] shortname);
 
 /**
  * Get the maximum purchased level of an upgrade of a client.
@@ -320,7 +310,7 @@ native SMRPG_GetClientUpgradeLevel(client, const String:shortname[]);
  * @return The level of the upgrade the client has purchased. 0 if he didn't buy it yet.
  * @error Invalid client index, unknown upgrade shortname.
  */
-native SMRPG_GetClientPurchasedUpgradeLevel(client, const String:shortname[]);
+native int SMRPG_GetClientPurchasedUpgradeLevel(int client, const char[] shortname);
 
 /**
  * Check if a client has the reached the maximum level of an upgrade.
@@ -329,7 +319,7 @@ native SMRPG_GetClientPurchasedUpgradeLevel(client, const String:shortname[]);
  * @param shortname     The upgrade shortname.
  * @return True if client has the maximal upgrade level, false otherwise.
  */
-stock bool:SMRPG_IsClientUpgradeMaxed(client, const String:shortname[])
+stock bool SMRPG_IsClientUpgradeMaxed(int client, const char[] shortname)
 {
   new upgrade[UpgradeInfo];
   SMRPG_GetUpgradeInfo(shortname, upgrade);
@@ -349,7 +339,7 @@ stock bool:SMRPG_IsClientUpgradeMaxed(client, const String:shortname[])
  * @param iLevel         The new selected level of the upgrade.
  * @error Invalid client index, unknown upgrade shortname or purchased level lower than the one you want to select.
  */
-native bool:SMRPG_SetClientSelectedUpgradeLevel(client, const String:shortname[], iLevel);
+native bool SMRPG_SetClientSelectedUpgradeLevel(int client, const char[] shortname, int iLevel);
 
 /**
  * Lets a client buy an upgrade and increases his upgrade level by 1.
@@ -361,7 +351,7 @@ native bool:SMRPG_SetClientSelectedUpgradeLevel(client, const String:shortname[]
  * @return True, if the client bought the upgrade, false if some other plugin stopped the buying in SMRPG_OnBuyUpgrade.
  * @error Invalid client index, unknown upgrade shortname.
  */
-native bool:SMRPG_ClientBuyUpgrade(client, const String:shortname[]);
+native bool SMRPG_ClientBuyUpgrade(int client, const char[] shortname);
 
 /**
  * Lets a client sell an upgrade and decreases his upgrade level by 1.
@@ -373,7 +363,7 @@ native bool:SMRPG_ClientBuyUpgrade(client, const String:shortname[]);
  * @return True, if the client sold the upgrade, false if some other plugin stopped the selling in SMRPG_OnSellUpgrade.
  * @error Invalid client index, unknown upgrade shortname.
  */
-native bool:SMRPG_ClientSellUpgrade(client, const String:shortname[]);
+native bool SMRPG_ClientSellUpgrade(int client, const char[] shortname);
 
 /**
  * Called when a client buys an upgrade or in general, when a client's upgrade level increases.
@@ -384,7 +374,7 @@ native bool:SMRPG_ClientSellUpgrade(client, const String:shortname[]);
  * @param newlevel       The new level, the client's upgrade will be set to.
  * @return >= Plugin_Handled to block the client from buying that upgrade, Plugin_Continue to let it pass.
  */
-forward Action:SMRPG_OnBuyUpgrade(client, const String:shortname[], newlevel);
+forward Action SMRPG_OnBuyUpgrade(int client, const char[] shortname, int newlevel);
 
 /**
  * Called after a client bought an upgrade or in general, when a client's upgrade level increased.
@@ -392,9 +382,8 @@ forward Action:SMRPG_OnBuyUpgrade(client, const String:shortname[], newlevel);
  * @param client         The client who bought an upgrade.
  * @param shortname      The upgrade shortname of the upgrade bought.
  * @param newlevel       The new level, the client's upgrade is set to.
- * @noreturn
  */
-forward SMRPG_OnBuyUpgradePost(client, const String:shortname[], newlevel);
+forward void SMRPG_OnBuyUpgradePost(int client, const char[] shortname, int newlevel);
 
 /**
  * Called when a client sells an upgrade or in general, when a client's upgrade level decreases.
@@ -405,7 +394,7 @@ forward SMRPG_OnBuyUpgradePost(client, const String:shortname[], newlevel);
  * @param newlevel       The new level, the client's upgrade will be set to.
  * @return >= Plugin_Handled to block the client from selling that upgrade, Plugin_Continue to let it pass.
  */
-forward Action:SMRPG_OnSellUpgrade(client, const String:shortname[], newlevel);
+forward Action SMRPG_OnSellUpgrade(int client, const char[] shortname, int newlevel);
 
 /**
  * Called after a client sold an upgrade or in general, when a client's upgrade level decreased.
@@ -413,9 +402,8 @@ forward Action:SMRPG_OnSellUpgrade(client, const String:shortname[], newlevel);
  * @param client         The client who sold an upgrade.
  * @param shortname      The upgrade shortname of the upgrade sold.
  * @param newlevel       The new level, the client's upgrade is set to.
- * @noreturn
  */
-forward SMRPG_OnSellUpgradePost(client, const String:shortname[], newlevel);
+forward void SMRPG_OnSellUpgradePost(int client, const char[] shortname, int newlevel);
 
 /**
  * Called when an upgrade is about to start his effect on a client.
@@ -426,16 +414,15 @@ forward SMRPG_OnSellUpgradePost(client, const String:shortname[], newlevel);
  * @param issuer         (Optional) The client which starts the effect on the target. (Same as target by default)
  * @return >= Plugin_Handled to tell the upgrade to NOT run the effect, Plugin_Continue to let it pass.
  */
-forward Action:SMRPG_OnUpgradeEffect(target, const String:shortname[], issuer);
+forward Action SMRPG_OnUpgradeEffect(int target, const char[] shortname, int issuer);
 
 /**
  * Called after the default convars of an upgrade have changed.
  * @see SMRPG_RegisterUpgradeType
  *
  * @param shortname      The shortname of the upgrade which settings have changed.
- * @noreturn
  */
-forward SMRPG_OnUpgradeSettingsChanged(const String:shortname[]);
+forward void SMRPG_OnUpgradeSettingsChanged(const char[] shortname);
 
 /**
  * Called when an upgrade is registered.
@@ -443,14 +430,12 @@ forward SMRPG_OnUpgradeSettingsChanged(const String:shortname[]);
  * @see SMRPG_OnClientLoaded.
  *
  * @param shortname      The shortname of the loaded upgrade.
- * @noreturn
  */
-forward SMRPG_OnUpgradeRegistered(const String:shortname[]);
+forward void SMRPG_OnUpgradeRegistered(const char[] shortname);
 
 /**
  * Called when an upgrade is unregistered from the core and is no longer available.
  *
  * @param shortname      The shortname of the loaded upgrade.
- * @noreturn
  */
-forward SMRPG_OnUpgradeUnregistered(const String:shortname[]);
+forward void SMRPG_OnUpgradeUnregistered(const char[] shortname);

--- a/scripting/include/smrpg_armorplus.inc
+++ b/scripting/include/smrpg_armorplus.inc
@@ -16,7 +16,7 @@
  * @param client  The client whos maxhealth you want to know.
  * @return        The client's maxhealth depending on his SM:RPG maxhealth level.
  */
-native SMRPG_Armor_GetClientMaxArmorEx(client);
+native int SMRPG_Armor_GetClientMaxArmorEx(int client);
 
 /**
  * Get the maximal health for a client, if the smrpg_upgrade_health plugin is loaded.
@@ -25,7 +25,7 @@ native SMRPG_Armor_GetClientMaxArmorEx(client);
  * @param client  The client whos maxhealth you want to know.
  * @return        The client's maxhealth depending on his SM:RPG maxhealth level, or default maxhealth, if SM:RPG unavailable.
  */
-stock SMRPG_Armor_GetClientMaxArmor(client)
+stock int SMRPG_Armor_GetClientMaxArmor(int client)
 {
 	// Use Armor+ maxlevel, if available.
 	if(GetFeatureStatus(FeatureType_Native, "SMRPG_Armor_GetClientMaxArmorEx") == FeatureStatus_Available)
@@ -34,7 +34,7 @@ stock SMRPG_Armor_GetClientMaxArmor(client)
 	return DEFAULT_MAX_ARMOR;
 }
 
-public SharedPlugin:__pl_smrpg_armorplus = 
+public SharedPlugin __pl_smrpg_armorplus = 
 {
 	name = "smrpg_armorplus",
 	file = "smrpg_upgrade_armorplus_cstrike.smx",
@@ -46,7 +46,7 @@ public SharedPlugin:__pl_smrpg_armorplus =
 };
 
 #if !defined REQUIRE_PLUGIN
-public __pl_smrpg_armorplus_SetNTVOptional()
+public void __pl_smrpg_armorplus_SetNTVOptional()
 {
 	MarkNativeAsOptional("SMRPG_Armor_GetClientMaxArmorEx");
 }

--- a/scripting/include/smrpg_commandlist.inc
+++ b/scripting/include/smrpg_commandlist.inc
@@ -25,7 +25,7 @@ enum CommandTranslationType {
  * @param maxlen      The maximal length of the buffer.
  * @return            Return Plugin_Handled to stop the command from being listed in the menu or the advert printed, otherwise return Plugin_Continue.
  */
-functag public Action:SMRPG_TranslateCommandCB(client, const String:command[], CommandTranslationType:type, String:translation[], maxlen);
+typedef SMRPG_TranslateCommandCB = function Action (int client, const char[] command, CommandTranslationType type, char[] translation, int maxlen);
 
 /**
  * Register a rpg related command in the core.
@@ -33,21 +33,19 @@ functag public Action:SMRPG_TranslateCommandCB(client, const String:command[], C
  *
  * @param command   The command you want to register.
  * @param callback  The callback to call to get the description and advert text.
- * @noreturn
  * @error Command already registered by other plugin.
  */
-native SMRPG_RegisterCommand(const String:command[], SMRPG_TranslateCommandCB:callback);
+native void SMRPG_RegisterCommand(const char[] command, SMRPG_TranslateCommandCB callback);
 
 /**
  * Unregister the rpg related command from the core.
  * Call this in OnPluginEnd!
  * 
  * @param command   The command you previously registered and want to unregister now.
- * @noreturn
  */
-native SMRPG_UnregisterCommand(const String:command[]);
+native void SMRPG_UnregisterCommand(const char[] command);
 
-public SharedPlugin:__pl_smrpg_commandlist = 
+public SharedPlugin __pl_smrpg_commandlist = 
 {
 	name = "smrpg_commandlist",
 	file = "smrpg_commandlist.smx",
@@ -59,7 +57,7 @@ public SharedPlugin:__pl_smrpg_commandlist =
 };
 
 #if !defined REQUIRE_PLUGIN
-public __pl_smrpg_commandlist_SetNTVOptional()
+public void __pl_smrpg_commandlist_SetNTVOptional()
 {
 	MarkNativeAsOptional("SMRPG_RegisterCommand");
 	MarkNativeAsOptional("SMRPG_UnregisterCommand");

--- a/scripting/include/smrpg_effects.inc
+++ b/scripting/include/smrpg_effects.inc
@@ -16,16 +16,15 @@
  * @return                   True if client was frozen, false otherwise.
  * @error                    Invalid client index.
  */
-native bool:SMRPG_FreezeClient(client, Float:fTime, Float:fDamageLimit, const String:sUpgradeName[], bool:bPlaySound=true, bool:bFadeColor=true, bool:bResetVelocity=false);
+native bool SMRPG_FreezeClient(int client, float fTime, float fDamageLimit, const char[] sUpgradeName, bool bPlaySound=true, bool bFadeColor=true, bool bResetVelocity=false);
 
 /**
  * Unfreeze a client, if he was frozen by SMRPG_FreezeClient previously.
  *
  * @param client             The client index.
- * @noreturn
  * @error                    Invalid client index or client not frozen.
  */
-native SMRPG_UnfreezeClient(client);
+native void SMRPG_UnfreezeClient(int client);
 
 /**
  * Checks whether a client is frozen by this plugin.
@@ -34,7 +33,7 @@ native SMRPG_UnfreezeClient(client);
  * @return                   True if frozen, false otherwise.
  * @error                    Invalid client index.
  */
-native bool:SMRPG_IsClientFrozen(client);
+native bool SMRPG_IsClientFrozen(int client);
 
 /**
  * Ignites a client. Can play optional effects on him.
@@ -47,16 +46,15 @@ native bool:SMRPG_IsClientFrozen(client);
  * @return                   True if client was ignited, false otherwise.
  * @error                    Invalid client index.
  */
-native bool:SMRPG_IgniteClient(client, Float:fTime, const String:sUpgradeName[], bool:bFadeColor=true, attacker=-1);
+native bool SMRPG_IgniteClient(int client, float fTime, const char[] sUpgradeName, bool bFadeColor=true, int attacker=-1);
 
 /**
  * Extinguish a client, if he was ignited by SMRPG_IgniteClient previously.
  *
  * @param client             The client index.
- * @noreturn
  * @error                    Invalid client index or client not burning.
  */
-native SMRPG_ExtinguishClient(client);
+native void SMRPG_ExtinguishClient(int client);
 
 /**
  * Checks whether a client is ignited by this plugin.
@@ -65,7 +63,7 @@ native SMRPG_ExtinguishClient(client);
  * @return                   True if burning, false otherwise.
  * @error                    Invalid client index.
  */
-native bool:SMRPG_IsClientBurning(client);
+native bool SMRPG_IsClientBurning(int client);
 
 /**
  * Set the default color of the player to reset to after some effects are run.
@@ -76,10 +74,9 @@ native bool:SMRPG_IsClientBurning(client);
  * @param g                  The green channel (0-255) or -1 to leave unchanged.
  * @param b                  The blue channel (0-255) or -1 to leave unchanged.
  * @param a                  The alpha channel (0-255) or -1 to leave unchanged.
- * @noreturn
  * @error                    Invalid client index.
  */
-native SMRPG_SetClientDefaultColor(client, r=-1, g=-1, b=-1, a=-1);
+native void SMRPG_SetClientDefaultColor(int client, int r=-1, int g=-1, int b=-1, int a=-1);
 
 /**
  * Set the render color of the player.
@@ -90,10 +87,9 @@ native SMRPG_SetClientDefaultColor(client, r=-1, g=-1, b=-1, a=-1);
  * @param g                  The green channel (0-255) or -1 to leave unchanged.
  * @param b                  The blue channel (0-255) or -1 to leave unchanged.
  * @param a                  The alpha channel (0-255) or -1 to leave unchanged.
- * @noreturn
  * @error                    Invalid client index.
  */
-native SMRPG_SetClientRenderColor(client, r=-1, g=-1, b=-1, a=-1);
+native void SMRPG_SetClientRenderColor(int client, int r=-1, int g=-1, int b=-1, int a=-1);
 
 /**
  * Start fading the render color from the current value to this target color.
@@ -108,7 +104,7 @@ native SMRPG_SetClientRenderColor(client, r=-1, g=-1, b=-1, a=-1);
  * @noreturn
  * @error                    Invalid client index.
  */
-native SMRPG_SetClientRenderColorFadeTarget(client, r=-1, g=-1, b=-1, a=-1);
+native void SMRPG_SetClientRenderColorFadeTarget(int client, int r=-1, int g=-1, int b=-1, int a=-1);
 
 /**
  * Set the fade stepsize for each channel. Every frame the channel moves by that stepsize towards the fade target.
@@ -122,7 +118,7 @@ native SMRPG_SetClientRenderColorFadeTarget(client, r=-1, g=-1, b=-1, a=-1);
  * @noreturn
  * @error                    Invalid client index.
  */
-native SMRPG_SetClientRenderColorFadeStepsize(client, Float:r=-1.0, Float:g=-1.0, Float:b=-1.0, Float:a=-1.0);
+native int SMRPG_SetClientRenderColorFadeStepsize(int client, float r=-1.0, float g=-1.0, float b=-1.0, float a=-1.0);
 
 /**
  * Reset the render color of the client back to the set default color.
@@ -137,10 +133,9 @@ native SMRPG_SetClientRenderColorFadeStepsize(client, Float:r=-1.0, Float:g=-1.0
  * @param bResetBlue         Should we reset the blue channel back to default?
  * @param bResetAlpha        Should we reset the alpha channel back to default?
  * @param bForceReset        Ignore which plugin last changed the channels and force a reset?
- * @noreturn
  * @error                    Invalid client index.
  */
-native SMRPG_ResetClientToDefaultColor(client, bool:bResetRed, bool:bResetGreen, bool:bResetBlue, bool:bResetAlpha, bool:bForceReset=false);
+native void SMRPG_ResetClientToDefaultColor(int client, bool bResetRed, bool bResetGreen, bool bResetBlue, bool bResetAlpha, bool bForceReset=false);
 
 /**
  * Determines if the player was slowed down or sped up.
@@ -167,7 +162,7 @@ enum LaggedMovementType {
  * @return                   True if players speed was changed, false otherwise. Could return false if the client is already slowed down further by another plugin than you want to set it to.
  * @error                    Invalid client index, negative fValue, negative fTime or fValue == 1.0. Use SMRPG_ResetClientLaggedMovement to reset to 1.0.
  */
-native bool:SMRPG_ChangeClientLaggedMovement(client, Float:fValue, Float:fTime);
+native bool SMRPG_ChangeClientLaggedMovement(int client, float fValue, float fTime);
 
 /**
  * Reset the previously changed speed of the player before the set time runs out.
@@ -180,7 +175,7 @@ native bool:SMRPG_ChangeClientLaggedMovement(client, Float:fValue, Float:fTime);
  * @return                   True if the speed of that type was reset, false otherwise.
  * @error                    Invalid client index.
  */
-native bool:SMRPG_ResetClientLaggedMovement(client, LaggedMovementType:type, bool:bForce=false);
+native bool SMRPG_ResetClientLaggedMovement(int client, LaggedMovementType type, bool bForce=false);
 
 /**
  * Check whether a client has his speed changed up or down (or both).
@@ -191,7 +186,7 @@ native bool:SMRPG_ResetClientLaggedMovement(client, LaggedMovementType:type, boo
  * @return                   True if speed was changed, false otherwise.
  * @error                    Invalid client index.
  */
-native bool:SMRPG_IsClientLaggedMovementChanged(client, LaggedMovementType:type, bool:bByMe=false);
+native bool SMRPG_IsClientLaggedMovementChanged(int client, LaggedMovementType type, bool bByMe=false);
 
 /**
  * Called when a client is about to be frozen for fTime seconds.
@@ -200,24 +195,22 @@ native bool:SMRPG_IsClientLaggedMovementChanged(client, LaggedMovementType:type,
  * @param &fTime     The time to freeze for. You can change it and return Plugin_Changed.
  * @return           >= Plugin_Handled to block, Plugin_Continue to allow freezing.
  */
-forward Action:SMRPG_OnClientFreeze(client, &Float:fTime);
+forward Action SMRPG_OnClientFreeze(int client, float &fTime);
 
 /**
  * Called when a client was frozen for fTime seconds.
  *
  * @param client     The client index.
  * @param fTime      The time to freeze for.
- * @noreturn
  */
-forward SMRPG_OnClientFrozen(client, Float:fTime);
+forward void SMRPG_OnClientFrozen(int client, float fTime);
 
 /**
  * Called when a client was unfrozen.
  *
  * @param client     The client index.
- * @noreturn
  */
-forward SMRPG_OnClientUnfrozen(client);
+forward void SMRPG_OnClientUnfrozen(int client);
 
 /**
  * Called when a client is about to be ignited for fTime seconds.
@@ -226,24 +219,22 @@ forward SMRPG_OnClientUnfrozen(client);
  * @param &fTime     The time to burn for. You can change it and return Plugin_Changed.
  * @return           >= Plugin_Handled to block, Plugin_Continue to allow burning.
  */
-forward Action:SMRPG_OnClientIgnite(client, &Float:fTime);
+forward Action SMRPG_OnClientIgnite(int client, float &fTime);
 
 /**
  * Called when a client was ignited for fTime seconds.
  *
  * @param client     The client index.
  * @param fTime      The time to freeze for.
- * @noreturn
  */
-forward SMRPG_OnClientIgnited(client, Float:fTime);
+forward void SMRPG_OnClientIgnited(int client, float fTime);
 
 /**
  * Called when a client was extinguished.
  *
  * @param client     The client index.
- * @noreturn
  */
-forward SMRPG_OnClientExtinguished(client);
+forward void SMRPG_OnClientExtinguished(int client);
 
 /**
  * Called when the speed of a client is about to be changed for fTime seconds.
@@ -253,7 +244,7 @@ forward SMRPG_OnClientExtinguished(client);
  * @param &fTime     The time to change the speed for. You can change it and return Plugin_Changed.
  * @return           >= Plugin_Handled to block, Plugin_Continue to allow the change of the speed.
  */
-forward Action:SMRPG_OnClientLaggedMovementChange(client, LaggedMovementType:type, &Float:fTime);
+forward Action SMRPG_OnClientLaggedMovementChange(int client, LaggedMovementType type, float &fTime);
 
 /**
  * Called after the speed of a client was changed.
@@ -261,20 +252,18 @@ forward Action:SMRPG_OnClientLaggedMovementChange(client, LaggedMovementType:typ
  * @param client     The client index.
  * @param type       The type of the speed change. LMT_Faster or LMT_Slower.
  * @param fTime      The time the speed is changed for.
- * @noreturn
  */
-forward SMRPG_OnClientLaggedMovementChanged(client, LaggedMovementType:type, Float:fTime);
+forward void SMRPG_OnClientLaggedMovementChanged(int client, LaggedMovementType type, float fTime);
 
 /**
  * Called when the speed of the client is reset to normal for the set type.
  * 
  * @param client     The client index.
  * @param type       The type of the reset speed change. LMT_Faster or LMT_Slower.
- * @noreturn
  */
-forward SMRPG_OnClientLaggedMovementReset(client, LaggedMovementType:type);
+forward void SMRPG_OnClientLaggedMovementReset(int client, LaggedMovementType type);
 
-public SharedPlugin:__pl_smrpg_effects = 
+public SharedPlugin __pl_smrpg_effects = 
 {
 	name = "smrpg_effects",
 	file = "smrpg_effects.smx",
@@ -286,7 +275,7 @@ public SharedPlugin:__pl_smrpg_effects =
 };
 
 #if !defined REQUIRE_PLUGIN
-public __pl_smrpg_effects_SetNTVOptional()
+public void __pl_smrpg_effects_SetNTVOptional()
 {
 	MarkNativeAsOptional("SMRPG_FreezeClient");
 	MarkNativeAsOptional("SMRPG_UnfreezeClient");

--- a/scripting/include/smrpg_effects.inc
+++ b/scripting/include/smrpg_effects.inc
@@ -101,7 +101,6 @@ native void SMRPG_SetClientRenderColor(int client, int r=-1, int g=-1, int b=-1,
  * @param g                  The green channel (0-255) or -1 to leave unchanged.
  * @param b                  The blue channel (0-255) or -1 to leave unchanged.
  * @param a                  The alpha channel (0-255) or -1 to leave unchanged.
- * @noreturn
  * @error                    Invalid client index.
  */
 native void SMRPG_SetClientRenderColorFadeTarget(int client, int r=-1, int g=-1, int b=-1, int a=-1);
@@ -115,7 +114,6 @@ native void SMRPG_SetClientRenderColorFadeTarget(int client, int r=-1, int g=-1,
  * @param g                  The step size for the green channel or -1 to leave unchanged.
  * @param b                  The step size for the blue channel or -1 to leave unchanged.
  * @param a                  The step size for the alpha channel or -1 to leave unchanged.
- * @noreturn
  * @error                    Invalid client index.
  */
 native int SMRPG_SetClientRenderColorFadeStepsize(int client, float r=-1.0, float g=-1.0, float b=-1.0, float a=-1.0);

--- a/scripting/include/smrpg_health.inc
+++ b/scripting/include/smrpg_health.inc
@@ -10,7 +10,7 @@
  * @param client  The client whos maxhealth you want to know.
  * @return        The client's maxhealth depending on his SM:RPG maxhealth level.
  */
-native SMRPG_Health_GetClientMaxHealthEx(client);
+native int SMRPG_Health_GetClientMaxHealthEx(int client);
 
 /**
  * Get the maximal health for a client, if the smrpg_upgrade_health plugin is loaded.
@@ -19,7 +19,7 @@ native SMRPG_Health_GetClientMaxHealthEx(client);
  * @param client  The client whos maxhealth you want to know.
  * @return        The client's maxhealth depending on his SM:RPG maxhealth level, or default maxhealth, if SM:RPG unavailable.
  */
-stock SMRPG_Health_GetClientMaxHealth(client)
+stock int SMRPG_Health_GetClientMaxHealth(int client)
 {
 	// Use Health+ maxlevel, if available.
 	if(GetFeatureStatus(FeatureType_Native, "SMRPG_Health_GetClientMaxHealthEx") == FeatureStatus_Available)
@@ -28,7 +28,7 @@ stock SMRPG_Health_GetClientMaxHealth(client)
 	return GetEntProp(client, Prop_Data, "m_iMaxHealth");
 }
 
-public SharedPlugin:__pl_smrpg_health = 
+public SharedPlugin __pl_smrpg_health = 
 {
 	name = "smrpg_health",
 	file = "smrpg_upgrade_health.smx",
@@ -40,7 +40,7 @@ public SharedPlugin:__pl_smrpg_health =
 };
 
 #if !defined REQUIRE_PLUGIN
-public __pl_smrpg_health_SetNTVOptional()
+public void __pl_smrpg_health_SetNTVOptional()
 {
 	MarkNativeAsOptional("SMRPG_Health_GetClientMaxHealthEx");
 }

--- a/scripting/include/smrpg_helper.inc
+++ b/scripting/include/smrpg_helper.inc
@@ -33,25 +33,25 @@
  * @param dir           Sound direction.
  * @param updatePos     Unknown (updates positions?)
  * @param soundtime     Alternate time to play sound for.
- * @noreturn
  * @error Invalid client index.
  */
-stock SMRPG_EmitSoundToAllEnabled(const String:shortname[], 
-				 const String:sample[],
-				 entity = SOUND_FROM_PLAYER,
-				 channel = SNDCHAN_AUTO,
-				 level = SNDLEVEL_NORMAL,
-				 flags = SND_NOFLAGS,
-				 Float:volume = SNDVOL_NORMAL,
-				 pitch = SNDPITCH_NORMAL,
-				 speakerentity = -1,
-				 const Float:origin[3] = NULL_VECTOR,
-				 const Float:dir[3] = NULL_VECTOR,
-				 bool:updatePos = true,
-				 Float:soundtime = 0.0)
+stock void SMRPG_EmitSoundToAllEnabled(const char[] shortname, 
+				 const char[] sample,
+				 int entity = SOUND_FROM_PLAYER,
+				 int channel = SNDCHAN_AUTO,
+				 int level = SNDLEVEL_NORMAL,
+				 int flags = SND_NOFLAGS,
+				 float volume = SNDVOL_NORMAL,
+				 int pitch = SNDPITCH_NORMAL,
+				 int speakerentity = -1,
+				 const float origin[3] = NULL_VECTOR,
+				 const float dir[3] = NULL_VECTOR,
+				 bool updatePos = true,
+				 float soundtime = 0.0)
 {
-	new iClients[MaxClients], iNumClients;
-	for(new i=1;i<=MaxClients;i++)
+	int[] iClients = new int[MaxClients];
+	int iNumClients;
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i) && SMRPG_ClientWantsCosmetics(i, shortname, SMRPG_FX_Sounds))
 			iClients[iNumClients++] = i;
@@ -69,12 +69,12 @@ stock SMRPG_EmitSoundToAllEnabled(const String:shortname[],
  *
  * @param shortname Shortname of the upgrade.
  * @param delay     Delay in seconds to send the TE.
- * @noreturn
  */
-stock SMRPG_TE_SendToAllEnabled(const String:shortname[], Float:delay=0.0)
+stock void SMRPG_TE_SendToAllEnabled(const char[] shortname, float delay=0.0)
 {
-	new iClients[MaxClients], iNumClients;
-	for (new i=1; i<=MaxClients; i++)
+	int[] iClients = new int[MaxClients];
+	int iNumClients;
+	for (int i=1; i<=MaxClients; i++)
 	{
 		if (IsClientInGame(i) && SMRPG_ClientWantsCosmetics(i, shortname, SMRPG_FX_Visuals))
 		{

--- a/scripting/include/smrpg_sharedmaterials.inc
+++ b/scripting/include/smrpg_sharedmaterials.inc
@@ -4,12 +4,10 @@
 
 /**
  * Loads the smrpg_sharedmaterials.games gamedata file and errors if it fails.
- * 
- * @noreturn
  */
-stock SMRPG_GC_CheckSharedMaterialsAndSounds(const String:sGameDataFile[] = "smrpg_sharedmaterials.games")
+stock void SMRPG_GC_CheckSharedMaterialsAndSounds(const char[] sGameDataFile = "smrpg_sharedmaterials.games")
 {
-	if(SMRPG_GC_GetSMRPGGameData(sGameDataFile) == INVALID_HANDLE)
+	if(SMRPG_GC_GetSMRPGGameData(sGameDataFile) == null)
 		SetFailState("Missing required gamedata %s!", sGameDataFile);
 }
 
@@ -19,9 +17,9 @@ stock SMRPG_GC_CheckSharedMaterialsAndSounds(const String:sGameDataFile[] = "smr
  * @param key	The key to search for in the gamedata file.
  * @return		The value of the key in the gamedata file.
  */
-stock String:SMRPG_GC_GetKeyValue(const String:key[])
+stock char[] SMRPG_GC_GetKeyValue(const char[] key)
 {
-	new String:sBuffer[PLATFORM_MAX_PATH];
+	char sBuffer[PLATFORM_MAX_PATH];
 	GameConfGetKeyValue(SMRPG_GC_GetSMRPGGameData(), key, sBuffer, sizeof(sBuffer));
 	return sBuffer;
 }
@@ -32,11 +30,11 @@ stock String:SMRPG_GC_GetKeyValue(const String:key[])
  * @param key	The key of the modelpath in the gamedata file.
  * @return		Modelindex of the precached model.
  */
-stock SMRPG_GC_PrecacheModel(const String:key[])
+stock int SMRPG_GC_PrecacheModel(const char[] key)
 {
-	new String:sBuffer[PLATFORM_MAX_PATH];
+	char sBuffer[PLATFORM_MAX_PATH];
 	sBuffer = SMRPG_GC_GetKeyValue(key);
-	new iIndex = -1;
+	int iIndex = -1;
 	if(sBuffer[0] != '\0')
 	{
 		iIndex = PrecacheModel(sBuffer);
@@ -51,11 +49,11 @@ stock SMRPG_GC_PrecacheModel(const String:key[])
  * @param key	The key of the soundpath in the gamedata file.
  * @return		True if precached successfully, false otherwise.
  */
-stock bool:SMRPG_GC_PrecacheSound(const String:key[])
+stock bool SMRPG_GC_PrecacheSound(const char[] key)
 {
-	new String:sBuffer[PLATFORM_MAX_PATH];
+	char sBuffer[PLATFORM_MAX_PATH];
 	sBuffer = SMRPG_GC_GetKeyValue(key);
-	new bool:bSuccess;
+	bool bSuccess;
 	if(sBuffer[0] != '\0')
 	{
 		bSuccess = PrecacheSound(sBuffer, true);
@@ -69,9 +67,9 @@ stock bool:SMRPG_GC_PrecacheSound(const String:key[])
  * @param key	The key of the model in the gamedata file.
  * @return		The precached model index if it was precached, -1 if not precached or failed.
  */
-stock SMRPG_GC_GetPrecachedIndex(const String:key[])
+stock int SMRPG_GC_GetPrecachedIndex(const char[] key)
 {
-	new iValue = -1;
+	int iValue = -1;
 	GetTrieValue(SMRPG_GC_GetGameDataCache(), key, iValue);
 	return iValue;
 }
@@ -84,11 +82,11 @@ stock SMRPG_GC_GetPrecachedIndex(const String:key[])
 /**
  * Gets the Handle to the smrpg_sharedmaterials.games gameconfig.
  * 
- * @return Handle to the smrpg_sharedmaterials.games gameconfig or INVALID_HANDLE if not found.
+ * @return Handle to the smrpg_sharedmaterials.games gameconfig or null if not found.
  */
-stock Handle:SMRPG_GC_GetSMRPGGameData(const String:sGameDataFile[] = "")
+stock Handle SMRPG_GC_GetSMRPGGameData(const char[] sGameDataFile = "")
 {
-	static Handle:hGameData = INVALID_HANDLE;
+	static Handle hGameData = null;
 	if(!hGameData && sGameDataFile[0] != '\0')
 	{
 		hGameData = LoadGameConfigFile(sGameDataFile);
@@ -102,12 +100,12 @@ stock Handle:SMRPG_GC_GetSMRPGGameData(const String:sGameDataFile[] = "")
  * 
  * @return Handle to the precached models indices trie.
  */
-stock Handle:SMRPG_GC_GetGameDataCache()
+stock StringMap SMRPG_GC_GetGameDataCache()
 {
-	static Handle:hCache = INVALID_HANDLE;
+	static StringMap hCache = null;
 	if(!hCache)
 	{
-		hCache = CreateTrie();
+		hCache = new StringMap();
 	}
 	return hCache;
 }

--- a/scripting/smrpg.sp
+++ b/scripting/smrpg.sp
@@ -92,8 +92,6 @@ ConVar g_hCVFadeOnLevelColor;
 // List of default core chat commands available to players, which get registered with the smrpg_commandlist plugin.
 char g_sDefaultRPGCommands[] = {"rpgmenu", "rpgrank", "rpginfo", "rpgtop10", "rpgnext", "rpgsession", "rpghelp", "rpgexp"};
 
-#define IF_IGNORE_BOTS(%1) if(IsFakeClient(%1) && (!g_hCVBotEnable.BoolValue || (g_hCVBotNeedHuman.BoolValue && Client_GetCount(true, false) == 0)))
-
 #include "smrpg/smrpg_upgrades.sp"
 #include "smrpg/smrpg_database.sp"
 #include "smrpg/smrpg_settings.sp"

--- a/scripting/smrpg/smrpg_admincommands.sp
+++ b/scripting/smrpg/smrpg_admincommands.sp
@@ -1,7 +1,7 @@
 #pragma semicolon 1
 #include <sourcemod>
 
-RegisterAdminCommands()
+void RegisterAdminCommands()
 {
 	RegAdminCmd("sm_rpgadmin", Cmd_OpenRPGAdminMenu, ADMFLAG_CONFIG, "Opens the SM:RPG admin menu.", "smrpg");
 	RegAdminCmd("smrpg_player", Cmd_PlayerInfo, ADMFLAG_ROOT, "Get info about a certain player. Usage smrpg_player <player name | #userid | #steamid>", "smrpg");
@@ -32,7 +32,7 @@ RegisterAdminCommands()
 	RegAdminCmd("smrpg_debug_playerlist", Cmd_DebugPlayerlist, ADMFLAG_ROOT, "List all RPG players", "smrpg");
 }
 
-public Action:Cmd_OpenRPGAdminMenu(client, args)
+public Action Cmd_OpenRPGAdminMenu(int client, int args)
 {
 	if (!client)
 	{
@@ -46,32 +46,32 @@ public Action:Cmd_OpenRPGAdminMenu(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_PlayerInfo(client, args)
+public Action Cmd_PlayerInfo(int client, int args)
 {
-	decl String:sText[256];
+	char sText[256];
 	GetCmdArgString(sText, sizeof(sText));
 	TrimString(sText);
-	new iTarget = FindTarget(client, sText, false, false);
+	int iTarget = FindTarget(client, sText, false, false);
 	if(iTarget == -1)
 		return Plugin_Handled;
 	
 	ReplyToCommand(client, "SM:RPG: ----------");
 	ReplyToCommand(client, "SM:RPG %N: ", iTarget);
 	
-	new playerInfo[PlayerInfo];
+	int playerInfo[PlayerInfo];
 	GetClientRPGInfo(iTarget, playerInfo);
 	
-	new String:sSteamID[64];
+	char sSteamID[64];
 	GetClientAuthId(iTarget, AuthId_Engine, sSteamID, sizeof(sSteamID));
 	ReplyToCommand(client, "SM:RPG Info: Index: %d, UserID: %d, SteamID: %s, Database ID: %d, AFK: %d", iTarget, GetClientUserId(iTarget), sSteamID, playerInfo[PLR_dbId], IsClientAFK(iTarget));
 	
 	ReplyToCommand(client, "SM:RPG Stats: Level: %d, Experience: %d/%d, Credits: %d, Rank: %d/%d", GetClientLevel(iTarget), GetClientExperience(iTarget), Stats_LvlToExp(GetClientLevel(iTarget)), GetClientCredits(iTarget), GetClientRank(iTarget), GetRankCount());
 	
 	ReplyToCommand(client, "SM:RPG Upgrades: ");
-	new iSize = GetUpgradeCount();
-	new upgrade[InternalUpgradeInfo];
-	decl String:sPermission[30];
-	for(new i=0;i<iSize;i++)
+	int iSize = GetUpgradeCount();
+	int upgrade[InternalUpgradeInfo];
+	char sPermission[30];
+	for(int i=0;i<iSize;i++)
 	{
 		GetUpgradeByIndex(i, upgrade);
 		if(!IsValidUpgrade(upgrade))
@@ -95,15 +95,15 @@ public Action:Cmd_PlayerInfo(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_ResetStats(client, args)
+public Action Cmd_ResetStats(int client, int args)
 {
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArgString(sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -117,7 +117,7 @@ public Action:Cmd_ResetStats(client, args)
 		return Plugin_Handled;
 	}
 	
-	for(new i=0;i<iTargetCount;i++)
+	for(int i=0;i<iTargetCount;i++)
 	{
 		ResetStats(iTargetList[i]);
 		SetPlayerLastReset(iTargetList[i], GetTime());
@@ -138,15 +138,15 @@ public Action:Cmd_ResetStats(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_ResetExp(client, args)
+public Action Cmd_ResetExp(int client, int args)
 {
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArgString(sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -160,9 +160,9 @@ public Action:Cmd_ResetExp(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iFailedTargets[MAXPLAYERS];
-	new iFailedCount;
-	for(new i=0;i<iTargetCount;i++)
+	int iFailedTargets[MAXPLAYERS];
+	int iFailedCount;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		if(SetClientExperience(iTargetList[i], 0))
 		{
@@ -180,9 +180,9 @@ public Action:Cmd_ResetExp(client, args)
 		ReplyToCommand(client, "SM:RPG resetexp: Experience has been reset for %t (%d players).", sTargetName, iTargetCount);
 		if(iFailedCount > 0)
 		{
-			decl String:sFailedList[1024];
+			char sFailedList[1024];
 			Format(sFailedList, sizeof(sFailedList), "SM:RPG resetexp: Can't reset experience for %d client(s) (blocked by other plugin): ", iFailedCount);
-			for(new i=0;i<iFailedCount;i++)
+			for(int i=0;i<iFailedCount;i++)
 			{
 				Format(sFailedList, sizeof(sFailedList), "%s%s %N", sFailedList, (i>0?",":""), iFailedTargets[i]);
 			}
@@ -200,7 +200,7 @@ public Action:Cmd_ResetExp(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_SetLvl(client, args)
+public Action Cmd_SetLvl(int client, int args)
 {
 	if(args < 2)
 	{
@@ -208,13 +208,13 @@ public Action:Cmd_SetLvl(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sLevel[16];
+	char sLevel[16];
 	GetCmdArg(2, sLevel, sizeof(sLevel));
-	new iLevel = StringToInt(sLevel);
+	int iLevel = StringToInt(sLevel);
 	
 	if(iLevel < 1)
 	{
@@ -222,9 +222,9 @@ public Action:Cmd_SetLvl(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -238,10 +238,10 @@ public Action:Cmd_SetLvl(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iLastOldLevel;
-	new iFailedTargets[MAXPLAYERS], iFailedOldLevels[MAXPLAYERS];
-	new iFailedCount;
-	for(new i=0;i<iTargetCount;i++)
+	int iLastOldLevel;
+	int iFailedTargets[MAXPLAYERS], iFailedOldLevels[MAXPLAYERS];
+	int iFailedCount;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		iLastOldLevel = GetClientLevel(iTargetList[i]);
 		// Don't touch players who already are on the desired level.
@@ -259,7 +259,7 @@ public Action:Cmd_SetLvl(client, args)
 			SetClientLevel(iTargetList[i], iLevel);
 			SetClientExperience(iTargetList[i], 0);
 			
-			if(GetConVarBool(g_hCVAnnounceNewLvl))
+			if(g_hCVAnnounceNewLvl.BoolValue)
 				Client_PrintToChatAll(false, "%t", "Client level changed", iTargetList[i], GetClientLevel(iTargetList[i]));
 		}
 		
@@ -279,9 +279,9 @@ public Action:Cmd_SetLvl(client, args)
 		ReplyToCommand(client, "SM:RPG setlvl: Level has been set to %d for %t (%d players).", iLevel, sTargetName, iTargetCount);
 		if(iFailedCount > 0)
 		{
-			decl String:sFailedList[1024];
+			char sFailedList[1024];
 			Format(sFailedList, sizeof(sFailedList), "SM:RPG setlvl: %d clients failed: ", iFailedCount);
-			for(new i=0;i<iFailedCount;i++)
+			for(int i=0;i<iFailedCount;i++)
 			{
 				Format(sFailedList, sizeof(sFailedList), "%s%s%N (level: %d, old: %d)", sFailedList, (i>0?", ":""), iFailedTargets[i], GetClientLevel(iFailedTargets[0]), iFailedOldLevels[0]);
 			}
@@ -296,7 +296,7 @@ public Action:Cmd_SetLvl(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_AddLvl(client, args)
+public Action Cmd_AddLvl(int client, int args)
 {
 	if(args < 2)
 	{
@@ -304,13 +304,13 @@ public Action:Cmd_AddLvl(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sLevel[16];
+	char sLevel[16];
 	GetCmdArg(2, sLevel, sizeof(sLevel));
-	new iLevelIncrease = StringToInt(sLevel);
+	int iLevelIncrease = StringToInt(sLevel);
 	
 	if(iLevelIncrease < 1)
 	{
@@ -318,9 +318,9 @@ public Action:Cmd_AddLvl(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -334,10 +334,10 @@ public Action:Cmd_AddLvl(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iLastOldLevel;
-	new iFailedTargets[MAXPLAYERS], iFailedOldLevels[MAXPLAYERS];
-	new iFailedCount;
-	for(new i=0;i<iTargetCount;i++)
+	int iLastOldLevel;
+	int iFailedTargets[MAXPLAYERS], iFailedOldLevels[MAXPLAYERS];
+	int iFailedCount;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		iLastOldLevel = GetClientLevel(iTargetList[i]);
 		
@@ -360,9 +360,9 @@ public Action:Cmd_AddLvl(client, args)
 		ReplyToCommand(client, "SM:RPG addlvl: Added %d levels to %t (%d players).", iLevelIncrease, sTargetName, iTargetCount);
 		if(iFailedCount > 0)
 		{
-			decl String:sFailedList[1024];
+			char sFailedList[1024];
 			Format(sFailedList, sizeof(sFailedList), "SM:RPG addlvl: %d clients failed: ", iFailedCount);
-			for(new i=0;i<iFailedCount;i++)
+			for(int i=0;i<iFailedCount;i++)
 			{
 				Format(sFailedList, sizeof(sFailedList), "%s%s%N (level: %d, old: %d)", sFailedList, (i>0?", ":""), iFailedTargets[i], GetClientLevel(iFailedTargets[0]), iFailedOldLevels[0]);
 			}
@@ -377,7 +377,7 @@ public Action:Cmd_AddLvl(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_SetExp(client, args)
+public Action Cmd_SetExp(int client, int args)
 {
 	if(args < 2)
 	{
@@ -385,13 +385,13 @@ public Action:Cmd_SetExp(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sExperience[16];
+	char sExperience[16];
 	GetCmdArg(2, sExperience, sizeof(sExperience));
-	new iExperience = StringToInt(sExperience);
+	int iExperience = StringToInt(sExperience);
 	
 	if(iExperience < 0)
 	{
@@ -399,9 +399,9 @@ public Action:Cmd_SetExp(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -415,9 +415,10 @@ public Action:Cmd_SetExp(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iLastOldLevel, iLastOldExperience;
-	new iFailCount, bool:bSuccess;
-	for(new i=0;i<iTargetCount;i++)
+	int iLastOldLevel, iLastOldExperience;
+	int iFailCount;
+	bool bSuccess;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		iLastOldLevel = GetClientLevel(iTargetList[i]);
 		iLastOldExperience = GetClientExperience(iTargetList[i]);
@@ -425,7 +426,7 @@ public Action:Cmd_SetExp(client, args)
 		// Do a proper level up if enough experience.
 		if(iExperience > iLastOldExperience)
 		{
-			new iNewExperience = iExperience-iLastOldExperience;
+			int iNewExperience = iExperience-iLastOldExperience;
 			bSuccess = Stats_AddExperience(iTargetList[i], iNewExperience, ExperienceReason_Admin, false, -1, true);
 		}
 		else
@@ -456,7 +457,7 @@ public Action:Cmd_SetExp(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_AddExp(client, args)
+public Action Cmd_AddExp(int client, int args)
 {
 	if(args < 2)
 	{
@@ -464,13 +465,13 @@ public Action:Cmd_AddExp(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sExperienceIncrease[16];
+	char sExperienceIncrease[16];
 	GetCmdArg(2, sExperienceIncrease, sizeof(sExperienceIncrease));
-	new iExperienceIncrease = StringToInt(sExperienceIncrease);
+	int iExperienceIncrease = StringToInt(sExperienceIncrease);
 	
 	if(iExperienceIncrease < 1)
 	{
@@ -478,9 +479,9 @@ public Action:Cmd_AddExp(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -494,9 +495,9 @@ public Action:Cmd_AddExp(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iLastOldLevel, iLastOldExperience;
-	new iFailCount;
-	for(new i=0;i<iTargetCount;i++)
+	int iLastOldLevel, iLastOldExperience;
+	int iFailCount;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		iLastOldLevel = GetClientLevel(iTargetList[i]);
 		iLastOldExperience = GetClientExperience(iTargetList[i]);
@@ -527,7 +528,7 @@ public Action:Cmd_AddExp(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_SetCredits(client, args)
+public Action Cmd_SetCredits(int client, int args)
 {
 	if(args < 2)
 	{
@@ -535,13 +536,13 @@ public Action:Cmd_SetCredits(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sCredits[16];
+	char sCredits[16];
 	GetCmdArg(2, sCredits, sizeof(sCredits));
-	new iCredits = StringToInt(sCredits);
+	int iCredits = StringToInt(sCredits);
 	
 	if(iCredits < 0)
 	{
@@ -549,9 +550,9 @@ public Action:Cmd_SetCredits(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -565,8 +566,8 @@ public Action:Cmd_SetCredits(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iLastOldCredits;
-	for(new i=0;i<iTargetCount;i++)
+	int iLastOldCredits;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		iLastOldCredits = GetClientCredits(iTargetList[i]);
 		
@@ -588,7 +589,7 @@ public Action:Cmd_SetCredits(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_AddCredits(client, args)
+public Action Cmd_AddCredits(int client, int args)
 {
 	if(args < 2)
 	{
@@ -596,13 +597,13 @@ public Action:Cmd_AddCredits(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sCredits[16];
+	char sCredits[16];
 	GetCmdArg(2, sCredits, sizeof(sCredits));
-	new iCredits = StringToInt(sCredits);
+	int iCredits = StringToInt(sCredits);
 	
 	if(iCredits < 1)
 	{
@@ -610,9 +611,9 @@ public Action:Cmd_AddCredits(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -626,8 +627,8 @@ public Action:Cmd_AddCredits(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iLastOldCredits;
-	for(new i=0;i<iTargetCount;i++)
+	int iLastOldCredits;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		iLastOldCredits = GetClientCredits(iTargetList[i]);
 		
@@ -649,13 +650,14 @@ public Action:Cmd_AddCredits(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_ListUpgrades(client, args)
+public Action Cmd_ListUpgrades(int client, int args)
 {
-	new iSize = GetUpgradeCount();
+	int iSize = GetUpgradeCount();
 	ReplyToCommand(client, "There are %d upgrades registered.", iSize);
-	new upgrade[InternalUpgradeInfo];
-	new iUnavailableCount, String:sPluginFile[64], String:sPermissions[30];
-	for(new i=0;i<iSize;i++)
+	int upgrade[InternalUpgradeInfo];
+	int iUnavailableCount;
+	char sPluginFile[64], sPermissions[30];
+	for(int i=0;i<iSize;i++)
 	{
 		GetUpgradeByIndex(i, upgrade);
 		if(!IsValidUpgrade(upgrade))
@@ -678,7 +680,7 @@ public Action:Cmd_ListUpgrades(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_SetUpgradeLvl(client, args)
+public Action Cmd_SetUpgradeLvl(int client, int args)
 {
 	if(args < 3)
 	{
@@ -686,27 +688,27 @@ public Action:Cmd_SetUpgradeLvl(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
+	char sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
 	GetCmdArg(2, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	new upgrade[InternalUpgradeInfo];
+	int upgrade[InternalUpgradeInfo];
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG: There is no upgrade with name \"%s\".", sUpgrade);
 		return Plugin_Handled;
 	}
 	
-	decl String:sLevel[16];
+	char sLevel[16];
 	GetCmdArg(3, sLevel, sizeof(sLevel));
 	StripQuotes(sLevel);
 	
 	// Make sure we're not over the maxlevel
-	new iLevel = StringToInt(sLevel);
+	int iLevel = StringToInt(sLevel);
 	if(StrEqual(sLevel, "max", false) || iLevel > upgrade[UPGR_maxLevel])
 		iLevel = upgrade[UPGR_maxLevel];
 	
@@ -716,11 +718,11 @@ public Action:Cmd_SetUpgradeLvl(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade[UPGR_index];
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -734,8 +736,8 @@ public Action:Cmd_SetUpgradeLvl(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iLastOldUpgradeLevel;
-	for(new i=0;i<iTargetCount;i++)
+	int iLastOldUpgradeLevel;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		iLastOldUpgradeLevel = GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex);
 		
@@ -776,7 +778,7 @@ public Action:Cmd_SetUpgradeLvl(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_GiveUpgrade(client, args)
+public Action Cmd_GiveUpgrade(int client, int args)
 {
 	if(args < 2)
 	{
@@ -784,26 +786,26 @@ public Action:Cmd_GiveUpgrade(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
+	char sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
 	GetCmdArg(2, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	new upgrade[InternalUpgradeInfo];
+	int upgrade[InternalUpgradeInfo];
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG giveupgrade: There is no upgrade with name \"%s\".", sUpgrade);
 		return Plugin_Handled;
 	}
 	
-	new iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade[UPGR_index];
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -817,10 +819,10 @@ public Action:Cmd_GiveUpgrade(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iLastOldUpgradeLevel;
-	new iCountAlreadyMaxed;
-	new iFailedTargets[MAXPLAYERS], iFailedCount;
-	for(new i=0;i<iTargetCount;i++)
+	int iLastOldUpgradeLevel;
+	int iCountAlreadyMaxed;
+	int iFailedTargets[MAXPLAYERS], iFailedCount;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		iLastOldUpgradeLevel = GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex);
 		
@@ -847,9 +849,9 @@ public Action:Cmd_GiveUpgrade(client, args)
 			ReplyToCommand(client, "SM:RPG giveupgrade: %d players already had it on max.", iCountAlreadyMaxed);
 		if(iFailedCount > 0)
 		{
-			decl String:sFailedList[1024];
+			char sFailedList[1024];
 			Format(sFailedList, sizeof(sFailedList), "SM:RPG giveupgrade: %d clients failed: ", iFailedCount);
-			for(new i=0;i<iFailedCount;i++)
+			for(int i=0;i<iFailedCount;i++)
 			{
 				Format(sFailedList, sizeof(sFailedList), "%s%s%N ", sFailedList, (i>0?", ":""), iFailedTargets[i]);
 			}
@@ -869,7 +871,7 @@ public Action:Cmd_GiveUpgrade(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_GiveAll(client, args)
+public Action Cmd_GiveAll(int client, int args)
 {
 	if(args < 1)
 	{
@@ -877,13 +879,13 @@ public Action:Cmd_GiveAll(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -897,12 +899,12 @@ public Action:Cmd_GiveAll(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iSize = GetUpgradeCount();
-	new upgrade[InternalUpgradeInfo];
-	for(new i=0;i<iTargetCount;i++)
+	int iSize = GetUpgradeCount();
+	int upgrade[InternalUpgradeInfo];
+	for(int i=0;i<iTargetCount;i++)
 	{
 		// Run through all upgrades
-		for(new u=0;u<iSize;u++)
+		for(int u=0;u<iSize;u++)
 		{
 			GetUpgradeByIndex(u, upgrade);
 			if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
@@ -929,7 +931,7 @@ public Action:Cmd_GiveAll(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_TakeUpgrade(client, args)
+public Action Cmd_TakeUpgrade(int client, int args)
 {
 	if(args < 2)
 	{
@@ -937,24 +939,24 @@ public Action:Cmd_TakeUpgrade(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
+	char sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
 	GetCmdArg(2, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	new upgrade[InternalUpgradeInfo];
+	int upgrade[InternalUpgradeInfo];
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG takeupgrade: There is no upgrade with shortname \"%s\".", sUpgrade);
 		return Plugin_Handled;
 	}
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -968,12 +970,12 @@ public Action:Cmd_TakeUpgrade(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade[UPGR_index];
 	
-	new iLastOldUpgradeLevel;
-	new iCountDontOwn;
-	new iFailedTargets[MAXPLAYERS], iFailedCount;
-	for(new i=0;i<iTargetCount;i++)
+	int iLastOldUpgradeLevel;
+	int iCountDontOwn;
+	int iFailedTargets[MAXPLAYERS], iFailedCount;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		iLastOldUpgradeLevel = GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex);
 		
@@ -1001,9 +1003,9 @@ public Action:Cmd_TakeUpgrade(client, args)
 			ReplyToCommand(client, "SM:RPG takeupgrade: %d players didn't own the upgrade at all.", iCountDontOwn);
 		if(iFailedCount > 0)
 		{
-			decl String:sFailedList[1024];
+			char sFailedList[1024];
 			Format(sFailedList, sizeof(sFailedList), "SM:RPG takeupgrade: %d clients failed: ", iFailedCount);
-			for(new i=0;i<iFailedCount;i++)
+			for(int i=0;i<iFailedCount;i++)
 			{
 				Format(sFailedList, sizeof(sFailedList), "%s%s%N ", sFailedList, (i>0?", ":""), iFailedTargets[i]);
 			}
@@ -1023,7 +1025,7 @@ public Action:Cmd_TakeUpgrade(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_BuyUpgrade(client, args)
+public Action Cmd_BuyUpgrade(int client, int args)
 {
 	if(args < 2)
 	{
@@ -1031,24 +1033,24 @@ public Action:Cmd_BuyUpgrade(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
+	char sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
 	GetCmdArg(2, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	new upgrade[InternalUpgradeInfo];
+	int upgrade[InternalUpgradeInfo];
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG buyupgrade: There is no upgrade with shortname \"%s\".", sUpgrade);
 		return Plugin_Handled;
 	}
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -1062,13 +1064,13 @@ public Action:Cmd_BuyUpgrade(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade[UPGR_index];
 	
-	new iLastOldUpgradeLevel;
-	new iCountAlreadyMaxed;
-	new iPoorTargets[MAXPLAYERS], iPoorCount;
-	new iFailedTargets[MAXPLAYERS], iFailedCount;
-	for(new i=0;i<iTargetCount;i++)
+	int iLastOldUpgradeLevel;
+	int iCountAlreadyMaxed;
+	int iPoorTargets[MAXPLAYERS], iPoorCount;
+	int iFailedTargets[MAXPLAYERS], iFailedCount;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		iLastOldUpgradeLevel = GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex);
 		
@@ -1080,7 +1082,7 @@ public Action:Cmd_BuyUpgrade(client, args)
 		}
 		
 		// Doesn't have enough credits.
-		new iCost = GetUpgradeCost(iIndex, iLastOldUpgradeLevel);
+		int iCost = GetUpgradeCost(iIndex, iLastOldUpgradeLevel);
 		if(iCost > GetClientCredits(iTargetList[i]))
 		{
 			iPoorTargets[iPoorCount++] = iTargetList[i];
@@ -1105,9 +1107,9 @@ public Action:Cmd_BuyUpgrade(client, args)
 			ReplyToCommand(client, "SM:RPG buyupgrade: %d players already had the upgrade at the maximal level.", iCountAlreadyMaxed);
 		if(iPoorCount > 0)
 		{
-			decl String:sPoorList[1024];
+			char sPoorList[1024];
 			Format(sPoorList, sizeof(sPoorList), "SM:RPG buyupgrade: %d clients don't have enough credits: ", iPoorCount);
-			for(new i=0;i<iPoorCount;i++)
+			for(int i=0;i<iPoorCount;i++)
 			{
 				Format(sPoorList, sizeof(sPoorList), "%s%s%N ", sPoorList, (i>0?", ":""), iPoorTargets[i]);
 			}
@@ -1115,9 +1117,9 @@ public Action:Cmd_BuyUpgrade(client, args)
 		}
 		if(iFailedCount > 0)
 		{
-			decl String:sFailedList[1024];
+			char sFailedList[1024];
 			Format(sFailedList, sizeof(sFailedList), "SM:RPG buyupgrade: %d clients failed: ", iFailedCount);
-			for(new i=0;i<iFailedCount;i++)
+			for(int i=0;i<iFailedCount;i++)
 			{
 				Format(sFailedList, sizeof(sFailedList), "%s%s%N ", sFailedList, (i>0?", ":""), iFailedTargets[i]);
 			}
@@ -1139,7 +1141,7 @@ public Action:Cmd_BuyUpgrade(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_SellUpgrade(client, args)
+public Action Cmd_SellUpgrade(int client, int args)
 {
 	if(args < 2)
 	{
@@ -1147,24 +1149,24 @@ public Action:Cmd_SellUpgrade(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
+	char sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
 	GetCmdArg(2, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	new upgrade[InternalUpgradeInfo];
+	int upgrade[InternalUpgradeInfo];
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG sellupgrade: There is no upgrade with name \"%s\".", sUpgrade);
 		return Plugin_Handled;
 	}
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -1178,12 +1180,12 @@ public Action:Cmd_SellUpgrade(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade[UPGR_index];
 	
-	new iLastOldUpgradeLevel;
-	new iCountDontOwn;
-	new iFailedTargets[MAXPLAYERS], iFailedCount;
-	for(new i=0;i<iTargetCount;i++)
+	int iLastOldUpgradeLevel;
+	int iCountDontOwn;
+	int iFailedTargets[MAXPLAYERS], iFailedCount;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		iLastOldUpgradeLevel = GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex);
 		
@@ -1201,7 +1203,7 @@ public Action:Cmd_SellUpgrade(client, args)
 		}
 		
 		// Full refund!
-		new iUpgradeCosts = GetUpgradeCost(iIndex, iLastOldUpgradeLevel);
+		int iUpgradeCosts = GetUpgradeCost(iIndex, iLastOldUpgradeLevel);
 		SetClientCredits(iTargetList[i], GetClientCredits(iTargetList[i]) + iUpgradeCosts);
 		
 		LogAction(client, iTargetList[i], "%L forced %L to sell a level of upgrade %s with full refund of the costs. The upgrade level changed from %d to %d and he received %d credits.", client, iTargetList[i], upgrade[UPGR_name], iLastOldUpgradeLevel, GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex), iUpgradeCosts);
@@ -1215,9 +1217,9 @@ public Action:Cmd_SellUpgrade(client, args)
 			ReplyToCommand(client, "SM:RPG sellupgrade: %d players didn't own the upgrade at all.", iCountDontOwn);
 		if(iFailedCount > 0)
 		{
-			decl String:sFailedList[1024];
+			char sFailedList[1024];
 			Format(sFailedList, sizeof(sFailedList), "SM:RPG sellupgrade: %d clients failed: ", iFailedCount);
-			for(new i=0;i<iFailedCount;i++)
+			for(int i=0;i<iFailedCount;i++)
 			{
 				Format(sFailedList, sizeof(sFailedList), "%s%s%N ", sFailedList, (i>0?", ":""), iFailedTargets[i]);
 			}
@@ -1237,7 +1239,7 @@ public Action:Cmd_SellUpgrade(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_SellAll(client, args)
+public Action Cmd_SellAll(int client, int args)
 {
 	if(args < 1)
 	{
@@ -1245,13 +1247,13 @@ public Action:Cmd_SellAll(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[256];
+	char sTarget[256];
 	GetCmdArg(1, sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	
-	decl String:sTargetName[MAX_TARGET_LENGTH];
-	new iTargetList[MAXPLAYERS], iTargetCount;
-	new bool:tn_is_ml;
+	char sTargetName[MAX_TARGET_LENGTH];
+	int iTargetList[MAXPLAYERS], iTargetCount;
+	bool tn_is_ml;
 	if((iTargetCount = ProcessTargetString(sTarget,
 							client, 
 							iTargetList,
@@ -1265,13 +1267,13 @@ public Action:Cmd_SellAll(client, args)
 		return Plugin_Handled;
 	}
 	
-	new iSize = GetUpgradeCount();
-	new upgrade[InternalUpgradeInfo];
-	new iLastCreditsReturned;
-	for(new i=0;i<iTargetCount;i++)
+	int iSize = GetUpgradeCount();
+	int upgrade[InternalUpgradeInfo];
+	int iLastCreditsReturned;
+	for(int i=0;i<iTargetCount;i++)
 	{
 		// Run through all upgrades
-		for(new u=0;u<iSize;u++)
+		for(int u=0;u<iSize;u++)
 		{
 			GetUpgradeByIndex(u, upgrade);
 			if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
@@ -1303,7 +1305,7 @@ public Action:Cmd_SellAll(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_DBDelPlayer(client, args)
+public Action Cmd_DBDelPlayer(int client, int args)
 {
 	if(args < 1)
 	{
@@ -1311,54 +1313,55 @@ public Action:Cmd_DBDelPlayer(client, args)
 		return Plugin_Handled;
 	}
 	
-	decl String:sTarget[64];
+	char sTarget[64];
 	GetCmdArgString(sTarget, sizeof(sTarget));
 	TrimString(sTarget);
 	StripQuotes(sTarget);
 	
-	decl String:sQuery[128], iPlayerID;
-	new Handle:hPack = CreateDataPack();
-	WritePackCell(hPack, client);
-	WritePackString(hPack, sTarget);
+	char sQuery[128];
+	int iPlayerID;
+	DataPack hPack = new DataPack();
+	hPack.WriteCell(client);
+	hPack.WriteString(sTarget);
 	
 	// Match as steamid
-	new iAccountId = GetAccountIdFromSteamId(sTarget);
+	int iAccountId = GetAccountIdFromSteamId(sTarget);
 	if(iAccountId != -1)
 	{
-		new iTarget = FindClientBySteamID(sTarget);
+		int iTarget = FindClientBySteamID(sTarget);
 		if(iTarget != -1)
 			RemovePlayer(iTarget);
 		
-		WritePackCell(hPack, iTarget);
+		hPack.WriteCell(iTarget);
 		Format(sQuery, sizeof(sQuery), "SELECT player_id, name FROM %s WHERE steamid = %d", TBL_PLAYERS, iAccountId);
-		SQL_TQuery(g_hDatabase, SQL_CheckDeletePlayer, sQuery, hPack);
+		g_hDatabase.Query(SQL_CheckDeletePlayer, sQuery, hPack);
 	}
 	// Match as playerid
 	else if(StringToIntEx(sTarget, iPlayerID) && iPlayerID > 0)
 	{
-		new iTarget = GetClientByPlayerID(iPlayerID);
+		int iTarget = GetClientByPlayerID(iPlayerID);
 		if(iTarget != -1)
 			RemovePlayer(iTarget);
 		
-		WritePackCell(hPack, iTarget);
+		hPack.WriteCell(iTarget);
 		Format(sQuery, sizeof(sQuery), "SELECT player_id, name FROM %s WHERE player_id = %d", TBL_PLAYERS, iPlayerID);
-		SQL_TQuery(g_hDatabase, SQL_CheckDeletePlayer, sQuery, hPack);
+		g_hDatabase.Query(SQL_CheckDeletePlayer, sQuery, hPack);
 	}
 	// Match as name
 	else
 	{
-		new iTarget = FindClientByExactName(sTarget);
+		int iTarget = FindClientByExactName(sTarget);
 		if(iTarget != -1)
 			RemovePlayer(iTarget);
 		
-		WritePackCell(hPack, iTarget);
+		hPack.WriteCell(iTarget);
 		Format(sQuery, sizeof(sQuery), "SELECT player_id, name FROM %s WHERE name = '%s'", TBL_PLAYERS, sTarget);
-		SQL_TQuery(g_hDatabase, SQL_CheckDeletePlayer, sQuery, hPack);
+		g_hDatabase.Query(SQL_CheckDeletePlayer, sQuery, hPack);
 	}
 	return Plugin_Handled;
 }
 
-public Action:Cmd_DBMassSell(client, args)
+public Action Cmd_DBMassSell(int client, int args)
 {
 	if(args < 1)
 	{
@@ -1367,22 +1370,22 @@ public Action:Cmd_DBMassSell(client, args)
 	}
 	
 	// TODO: check database for column instead of only currently loaded upgrades?
-	decl String:sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
+	char sUpgrade[MAX_UPGRADE_SHORTNAME_LENGTH];
 	GetCmdArg(1, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	new upgrade[InternalUpgradeInfo];
+	int upgrade[InternalUpgradeInfo];
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG: There is no upgrade with name \"%s\" loaded.", sUpgrade);
 		return Plugin_Handled;
 	}
 	
-	new iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade[UPGR_index];
 	
 	// Handle players ingame
-	new iOldLevel;
-	for(new i=1;i<=MaxClients;i++)
+	int iOldLevel;
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(!IsClientInGame(i) || !IsClientAuthorized(i))
 			continue;
@@ -1400,18 +1403,18 @@ public Action:Cmd_DBMassSell(client, args)
 	}
 	
 	// Update all other players in the database
-	new Handle:hData = CreateDataPack();
-	WritePackCell(hData, client);
-	WritePackCell(hData, iIndex);
+	DataPack hData = new DataPack();
+	hData.WriteCell(client);
+	hData.WriteCell(iIndex);
 	
-	decl String:sQuery[128];
+	char sQuery[128];
 	Format(sQuery, sizeof(sQuery), "SELECT player_id, purchasedlevel FROM %s WHERE upgrade_id = %d AND purchasedlevel > 0", TBL_PLAYERUPGRADES, upgrade[UPGR_databaseId]);
-	SQL_TQuery(g_hDatabase, SQL_MassDeleteItem, sQuery, hData);
+	g_hDatabase.Query(SQL_MassDeleteItem, sQuery, hData);
 	
 	return Plugin_Handled;
 }
 
-public Action:Cmd_ReloadWeaponExperience(client, args)
+public Action Cmd_ReloadWeaponExperience(int client, int args)
 {
 	if(ReadWeaponExperienceConfig())
 		ReplyToCommand(client, "SM:RPG > The weapon experience config has been reloaded.");
@@ -1421,9 +1424,9 @@ public Action:Cmd_ReloadWeaponExperience(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_DebugPlayerlist(client, args)
+public Action Cmd_DebugPlayerlist(int client, int args)
 {
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(!IsClientInGame(i))
 			continue;
@@ -1433,7 +1436,7 @@ public Action:Cmd_DebugPlayerlist(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_DBWrite(client, args)
+public Action Cmd_DBWrite(int client, int args)
 {
 	SaveAllPlayers();
 	LogAction(client, -1, "%L saved all player data to the database.", client);
@@ -1441,30 +1444,31 @@ public Action:Cmd_DBWrite(client, args)
 	return Plugin_Handled;
 }
 
-public Action:Cmd_DBStats(client, args)
+public Action Cmd_DBStats(int client, int args)
 {
-	decl String:sQuery[512];
+	char sQuery[512];
 	Format(sQuery, sizeof(sQuery), "SELECT COUNT(*) AS total, (SELECT COUNT(*) FROM %s WHERE lastseen > %d) AS recent, AVG(level) FROM %s", TBL_PLAYERS, GetTime()-432000, TBL_PLAYERS);
-	new Handle:hPack = CreateDataPack();
-	WritePackCell(hPack, client?GetClientSerial(client):0);
-	WritePackCell(hPack, _:GetCmdReplySource());
-	SQL_TQuery(g_hDatabase, SQL_PrintPlayerStats, sQuery, hPack);
+	DataPack hPack = new DataPack();
+	hPack.WriteCell(client?GetClientSerial(client):0);
+	hPack.WriteCell(GetCmdReplySource());
+	g_hDatabase.Query(SQL_PrintPlayerStats, sQuery, hPack);
 	return Plugin_Handled;
 }
 
 /**
  * SQL callbacks
  */
-public SQL_CheckDeletePlayer(Handle:owner, Handle:hndl, const String:error[], any:data)
+public void SQL_CheckDeletePlayer(Database db, DBResultSet results, const char[] error, any data)
 {
-	ResetPack(data);
-	new client = ReadPackCell(data);
-	new String:sTarget[64];
-	ReadPackString(data, sTarget, sizeof(sTarget));
-	new iTarget = ReadPackCell(data);
-	CloseHandle(data);
+	DataPack dp = view_as<DataPack>(data);
+	dp.Reset();
+	int client = dp.ReadCell();
+	char sTarget[64];
+	dp.ReadString(sTarget, sizeof(sTarget));
+	int iTarget = dp.ReadCell();
+	delete dp;
 	
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Error while trying to find player for deletion (%s)", error);
 		if(iTarget != -1)
@@ -1472,7 +1476,7 @@ public SQL_CheckDeletePlayer(Handle:owner, Handle:hndl, const String:error[], an
 		return;
 	}
 	
-	if(!SQL_GetRowCount(hndl) || !SQL_FetchRow(hndl))
+	if(!results.RowCount || !results.FetchRow())
 	{
 		if(client == 0 || IsClientInGame(client))
 		{
@@ -1483,22 +1487,22 @@ public SQL_CheckDeletePlayer(Handle:owner, Handle:hndl, const String:error[], an
 		return;
 	}
 	
-	new iPlayerId = SQL_FetchInt(hndl, 0);
-	if(GetConVarBool(g_hCVSaveData))
+	int iPlayerId = results.FetchInt(0);
+	if(g_hCVSaveData.BoolValue)
 	{
-		decl String:sQuery[128];
-		new Transaction:hTransaction = SQL_CreateTransaction();
+		char sQuery[128];
+		Transaction hTransaction = new Transaction();
 		Format(sQuery, sizeof(sQuery), "DELETE FROM %s WHERE player_id = %d", TBL_PLAYERUPGRADES, iPlayerId);
-		SQL_AddQuery(hTransaction, sQuery);
+		hTransaction.AddQuery(sQuery);
 		Format(sQuery, sizeof(sQuery), "DELETE FROM %s WHERE player_id = %d", TBL_PLAYERS, iPlayerId);
-		SQL_AddQuery(hTransaction, sQuery);
-		SQL_ExecuteTransaction(g_hDatabase, hTransaction, _, SQLTxn_LogFailure);
+		hTransaction.AddQuery(sQuery);
+		g_hDatabase.Execute(hTransaction, _, SQLTxn_LogFailure);
 		
 		if(iTarget != -1)
 			g_iPlayerInfo[iTarget][PLR_dbId] = -1;
 		
-		decl String:sName[64];
-		SQL_FetchString(hndl, 1, sName, sizeof(sName));
+		char sName[64];
+		results.FetchString(1, sName, sizeof(sName));
 		if(client == 0 || IsClientInGame(client))
 		{
 			if(iTarget != -1)
@@ -1521,24 +1525,25 @@ public SQL_CheckDeletePlayer(Handle:owner, Handle:hndl, const String:error[], an
 	
 }
 
-public SQL_MassDeleteItem(Handle:owner, Handle:hndl, const String:error[], any:data)
+public void SQL_MassDeleteItem(Database db, DBResultSet results, const char[] error, any data)
 {
-	ResetPack(data);
-	new client = ReadPackCell(data);
-	new iIndex = ReadPackCell(data);
-	CloseHandle(data);
+	DataPack dp = view_as<DataPack>(data);
+	dp.Reset();
+	int client = dp.ReadCell();
+	int iIndex = dp.ReadCell();
+	delete dp;
 	
-	new upgrade[InternalUpgradeInfo];
+	int upgrade[InternalUpgradeInfo];
 	GetUpgradeByIndex(iIndex, upgrade);
 	
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogAction(client, -1, "%L tried to mass sell upgrade \"%s\", but the select query failed. It might have been reset on some players ingame though!", client, upgrade[UPGR_name]);
 		LogError("Error during mass deletion of item (%s)", error);
 		return;
 	}
 	
-	if(SQL_GetRowCount(hndl) == 0)
+	if(results.RowCount == 0)
 	{
 		if(client == 0 || IsClientInGame(client))
 		{
@@ -1548,27 +1553,27 @@ public SQL_MassDeleteItem(Handle:owner, Handle:hndl, const String:error[], any:d
 		return;
 	}
 	
-	if(GetConVarBool(g_hCVSaveData))
+	if(g_hCVSaveData.BoolValue)
 	{
 		// Give players full refund for their upgrades.
-		new iOldLevel, iAddCredits, iPlayerID;
-		decl String:sQuery[128];
+		int iOldLevel, iAddCredits, iPlayerID;
+		char sQuery[128];
 		
 		// Update all players at once instead of firing lots of single update queries.
-		new Transaction:hTransaction = SQL_CreateTransaction();
+		Transaction hTransaction = new Transaction();
 		
-		while(SQL_MoreRows(hndl))
+		while(results.MoreRows)
 		{
-			if(!SQL_FetchRow(hndl))
+			if(!results.FetchRow())
 				continue;
 			
-			iPlayerID = SQL_FetchInt(hndl, 0);
+			iPlayerID = results.FetchInt(0);
 			
 			// This player is currently ingame and we already handled him. Don't add credits twice.
 			if(GetClientByPlayerID(iPlayerID) != -1)
 				continue;
 			
-			iOldLevel = SQL_FetchInt(hndl, 1);
+			iOldLevel = results.FetchInt(1);
 			if(iOldLevel < 0)
 			{
 				DebugMsg("Negative level for upgrade %s in database for player %d!", upgrade[UPGR_name], iPlayerID);
@@ -1585,19 +1590,19 @@ public SQL_MassDeleteItem(Handle:owner, Handle:hndl, const String:error[], any:d
 				iAddCredits += GetUpgradeCost(iIndex, iOldLevel--);
 			
 			Format(sQuery, sizeof(sQuery), "UPDATE %s SET credits = (credits + %d) WHERE player_id = %d", TBL_PLAYERS, iAddCredits, iPlayerID);
-			SQL_AddQuery(hTransaction, sQuery);
+			hTransaction.AddQuery(sQuery);
 		}
 		
-		SQL_ExecuteTransaction(g_hDatabase, hTransaction, _, SQLTxn_LogFailure);
+		g_hDatabase.Execute(hTransaction, _, SQLTxn_LogFailure);
 		
 		// Reset all players to upgrade level 0
 		Format(sQuery, sizeof(sQuery), "UPDATE %s SET purchasedlevel = 0, selectedlevel = 0 WHERE upgrade_id = %d", TBL_PLAYERUPGRADES, upgrade[UPGR_databaseId]);
-		SQL_TQuery(g_hDatabase, SQL_DoNothing, sQuery);
+		g_hDatabase.Query(SQL_DoNothing, sQuery);
 		
 		if(client == 0 || IsClientInGame(client))
 		{
-			LogAction(client, -1, "%L mass sold upgrade \"%s\" on all players with full costs refunded. %d players in the database have been refunded their credits.", client, upgrade[UPGR_name], SQL_GetRowCount(hndl));
-			ReplyToCommand(client, "SM:RPG db_mass_sell: All (%d) players in the database with Upgrade '%s' have been refunded their credits", SQL_GetRowCount(hndl), upgrade[UPGR_name]);
+			LogAction(client, -1, "%L mass sold upgrade \"%s\" on all players with full costs refunded. %d players in the database have been refunded their credits.", client, upgrade[UPGR_name], results.RowCount);
+			ReplyToCommand(client, "SM:RPG db_mass_sell: All (%d) players in the database with Upgrade '%s' have been refunded their credits", results.RowCount, upgrade[UPGR_name]);
 		}
 	}
 	else
@@ -1610,96 +1615,99 @@ public SQL_MassDeleteItem(Handle:owner, Handle:hndl, const String:error[], any:d
 	}
 }
 
-public SQL_PrintPlayerStats(Handle:owner, Handle:hndl, const String:error[], any:data)
+public void SQL_PrintPlayerStats(Database db, DBResultSet results, const char[] error, any data)
 {
-	ResetPack(data);
-	new client = GetClientFromSerial(ReadPackCell(data));
-	new ReplySource:source = ReplySource:ReadPackCell(data);
+	DataPack dp = view_as<DataPack>(data);
+	dp.Reset();
+	int client = GetClientFromSerial(dp.ReadCell());
+	ReplySource source = view_as<ReplySource>(dp.ReadCell());
 	
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Error getting player stats in smrpg_db_stats: %s", error);
-		CloseHandle(data);
+		delete dp;
 		return;
 	}
 
-	if(SQL_FetchRow(hndl))
+	if(results.FetchRow())
 	{
-		new ReplySource:oldSource = SetCmdReplySource(source);
-		new iPlayerCount = SQL_FetchInt(hndl, 0);
-		new iRecentPlayers = SQL_FetchInt(hndl, 1);
-		ReplyToCommand(client, "There are %d players in the database with an average level of %.2f. %d (%.2f%%) connected in the last 5 days.", iPlayerCount, SQL_FetchFloat(hndl, 2), iRecentPlayers, float(iRecentPlayers)/float(iPlayerCount)*100.0);
+		ReplySource oldSource = SetCmdReplySource(source);
+		int iPlayerCount = results.FetchInt(0);
+		int iRecentPlayers = results.FetchInt(1);
+		ReplyToCommand(client, "There are %d players in the database with an average level of %.2f. %d (%.2f%%) connected in the last 5 days.", iPlayerCount, SQL_FetchFloat(results, 2), iRecentPlayers, float(iRecentPlayers)/float(iPlayerCount)*100.0);
 		SetCmdReplySource(oldSource);
 	}
 	
-	decl String:sQuery[64];
+	char sQuery[64];
 	Format(sQuery, sizeof(sQuery), "SELECT upgrade_id, shortname FROM %s", TBL_UPGRADES);
-	SQL_TQuery(g_hDatabase, SQL_PrintUpgradeStats, sQuery, data);
+	g_hDatabase.Query(SQL_PrintUpgradeStats, sQuery, data);
 }
 
-public SQL_PrintUpgradeStats(Handle:owner, Handle:hndl, const String:error[], any:data)
+public void SQL_PrintUpgradeStats(Database db, DBResultSet results, const char[] error, any data)
 {
-	ResetPack(data);
-	new serial = ReadPackCell(data);
-	new client = GetClientFromSerial(serial);
-	new ReplySource:source = ReplySource:ReadPackCell(data);
+	DataPack dp = view_as<DataPack>(data);
+	dp.Reset();
+	int serial = dp.ReadCell();
+	int client = GetClientFromSerial(serial);
+	ReplySource source = view_as<ReplySource>(dp.ReadCell());
 	
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Error getting upgrade names in smrpg_db_stats: %s", error);
-		CloseHandle(data);
+		delete dp;
 		return;
 	}
 	
-	new ReplySource:oldSource = SetCmdReplySource(source);
-	ReplyToCommand(client, "Listing %d registered upgrades:", SQL_GetRowCount(hndl)-1);
+	ReplySource oldSource = SetCmdReplySource(source);
+	ReplyToCommand(client, "Listing %d registered upgrades:", results.RowCount-1);
 	ReplyToCommand(client, "%-15s%-8s%-10s%-8s", "Upgrade", "#bought", "AVG LVL", "Loaded");
 	SetCmdReplySource(oldSource);
 
-	decl String:sUpgradeName[MAX_UPGRADE_SHORTNAME_LENGTH];
-	decl String:sQuery[512];
-	new Handle:hPack;
-	while(SQL_MoreRows(hndl))
+	char sUpgradeName[MAX_UPGRADE_SHORTNAME_LENGTH];
+	char sQuery[512];
+	DataPack hPack;
+	while(results.MoreRows)
 	{
-		if(!SQL_FetchRow(hndl))
+		if(!results.FetchRow())
 			continue;
 		
-		SQL_FetchString(hndl, 1, sUpgradeName, sizeof(sUpgradeName));
+		results.FetchString(1, sUpgradeName, sizeof(sUpgradeName));
 		
-		hPack = CreateDataPack();
-		WritePackCell(hPack, serial);
-		WritePackCell(hPack, _:source);
-		WritePackString(hPack, sUpgradeName);
+		hPack = new DataPack();
+		hPack.WriteCell(serial);
+		hPack.WriteCell(source);
+		hPack.WriteString(sUpgradeName);
 		
-		Format(sQuery, sizeof(sQuery), "SELECT COUNT(*), AVG(purchasedlevel) FROM %s WHERE upgrade_id = %d AND purchasedlevel > 0", TBL_PLAYERUPGRADES, SQL_FetchInt(hndl, 0));
-		SQL_TQuery(g_hDatabase, SQL_PrintUpgradeUsage, sQuery, hPack);
+		Format(sQuery, sizeof(sQuery), "SELECT COUNT(*), AVG(purchasedlevel) FROM %s WHERE upgrade_id = %d AND purchasedlevel > 0", TBL_PLAYERUPGRADES, results.FetchInt(0));
+		g_hDatabase.Query(SQL_PrintUpgradeUsage, sQuery, hPack);
 	}
-	CloseHandle(data);
+	delete dp;
 }
 
-public SQL_PrintUpgradeUsage(Handle:owner, Handle:hndl, const String:error[], any:data)
+public void SQL_PrintUpgradeUsage(Database db, DBResultSet results, const char[] error, any data)
 {
-	ResetPack(data);
-	new client = GetClientFromSerial(ReadPackCell(data));
-	new ReplySource:source = ReplySource:ReadPackCell(data);
-	decl String:sUpgradeName[MAX_UPGRADE_SHORTNAME_LENGTH];
-	ReadPackString(data, sUpgradeName, sizeof(sUpgradeName));
-	CloseHandle(data);
+	DataPack dp = view_as<DataPack>(data);
+	dp.Reset();
+	int client = GetClientFromSerial(dp.ReadCell());
+	ReplySource source = view_as<ReplySource>(dp.ReadCell());
+	char sUpgradeName[MAX_UPGRADE_SHORTNAME_LENGTH];
+	dp.ReadString(sUpgradeName, sizeof(sUpgradeName));
+	delete dp;
 	
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Error getting upgrade stats in smrpg_db_stats: %s", error);
 		return;
 	}
 
-	new upgrade[InternalUpgradeInfo];
-	new ReplySource:oldSource = SetCmdReplySource(source);
-	while(SQL_MoreRows(hndl))
+	int upgrade[InternalUpgradeInfo];
+	ReplySource oldSource = SetCmdReplySource(source);
+	while(results.MoreRows)
 	{
-		if(!SQL_FetchRow(hndl))
+		if(!results.FetchRow())
 			continue;
 		
-		ReplyToCommand(client, "%-15s%-8d%-10.2f%-8s", sUpgradeName, SQL_FetchInt(hndl, 0), SQL_FetchFloat(hndl, 1), (GetUpgradeByShortname(sUpgradeName, upgrade)?"Yes":"No"));
+		ReplyToCommand(client, "%-15s%-8d%-10.2f%-8s", sUpgradeName, results.FetchInt(0), results.FetchFloat(1), (GetUpgradeByShortname(sUpgradeName, upgrade)?"Yes":"No"));
 	}
 	SetCmdReplySource(oldSource);
 }
@@ -1710,36 +1718,36 @@ public SQL_PrintUpgradeUsage(Handle:owner, Handle:hndl, const String:error[], an
 /**
  * Converts a steamid to the accountid.
  */
-stock GetAccountIdFromSteamId(String:sSteamID[])
+stock int GetAccountIdFromSteamId(char[] sSteamID)
 {
-	static Handle:hSteam2 = INVALID_HANDLE;
-	static Handle:hSteam3 = INVALID_HANDLE;
+	static Regex hSteam2 = null;
+	static Regex hSteam3 = null;
 	
-	if (hSteam2 == INVALID_HANDLE)
+	if (hSteam2 == null)
 		hSteam2 = CompileRegex("^STEAM_[0-9]:([0-9]):([0-9]+)$");
-	if (hSteam3 == INVALID_HANDLE)
+	if (hSteam3 == null)
 		hSteam3 = CompileRegex("^\\[U:[0-9]:([0-9]+)\\]$");
 	
-	new String:sBuffer[64];
+	char sBuffer[64];
 	
 	// Steam2 format?
-	if (hSteam2 != INVALID_HANDLE && MatchRegex(hSteam2, sSteamID) == 3)
+	if (hSteam2 != null && hSteam2.Match(sSteamID) == 3)
 	{
-		if(!GetRegexSubString(hSteam2, 1, sBuffer, sizeof(sBuffer)))
+		if(!hSteam2.GetSubString(1, sBuffer, sizeof(sBuffer)))
 			return -1;
 		
-		new Y = StringToInt(sBuffer);
-		if(!GetRegexSubString(hSteam2, 2, sBuffer, sizeof(sBuffer)))
+		int Y = StringToInt(sBuffer);
+		if(!hSteam2.GetSubString(2, sBuffer, sizeof(sBuffer)))
 			return -1;
 		
-		new Z = StringToInt(sBuffer);
+		int Z = StringToInt(sBuffer);
 		return Z*2 + Y;
 	}
 	
 	// Steam3 format?
-	if (hSteam3 != INVALID_HANDLE && MatchRegex(hSteam3, sSteamID) == 2)
+	if (hSteam3 != null && hSteam3.Match(sSteamID) == 2)
 	{
-		if(!GetRegexSubString(hSteam3, 1, sBuffer, sizeof(sBuffer)))
+		if(!hSteam3.GetSubString(1, sBuffer, sizeof(sBuffer)))
 			return -1;
 		
 		return StringToInt(sBuffer);
@@ -1748,10 +1756,10 @@ stock GetAccountIdFromSteamId(String:sSteamID[])
 	return -1;
 }
 
-stock FindClientBySteamID(const String:sSteamID[])
+stock int FindClientBySteamID(const char[] sSteamID)
 {
-	decl String:sTemp[64];
-	for(new i=1;i<=MaxClients;i++)
+	char sTemp[64];
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i) && IsClientAuthorized(i))
 		{
@@ -1767,10 +1775,10 @@ stock FindClientBySteamID(const String:sSteamID[])
 	return -1;
 }
 
-stock FindClientByExactName(const String:sName[])
+stock int FindClientByExactName(const char[] sName)
 {
-	decl String:sTemp[MAX_NAME_LENGTH];
-	for(new i=1;i<=MaxClients;i++)
+	char sTemp[MAX_NAME_LENGTH];
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i))
 		{
@@ -1782,13 +1790,13 @@ stock FindClientByExactName(const String:sName[])
 	return -1;
 }
 
-stock GetAdminFlagStringFromBits(flags, String:flagstring[], maxlen)
+stock void GetAdminFlagStringFromBits(int flags, char[] flagstring, int maxlen)
 {
-	new AdminFlag:iAdmFlags[AdminFlags_TOTAL];
-	new iNumFlags = FlagBitsToArray(flags, iAdmFlags, AdminFlags_TOTAL);
-	new iChar;
+	AdminFlag iAdmFlags[AdminFlags_TOTAL];
+	int iNumFlags = FlagBitsToArray(flags, iAdmFlags, AdminFlags_TOTAL);
+	int iChar;
 	flagstring[0] = 0;
-	for(new f=0;f<iNumFlags;f++)
+	for(int f=0;f<iNumFlags;f++)
 	{
 		if(FindFlagChar(iAdmFlags[f], iChar))
 			Format(flagstring, maxlen, "%s%c", flagstring, iChar);

--- a/scripting/smrpg/smrpg_admincommands.sp
+++ b/scripting/smrpg/smrpg_admincommands.sp
@@ -1458,15 +1458,14 @@ public Action Cmd_DBStats(int client, int args)
 /**
  * SQL callbacks
  */
-public void SQL_CheckDeletePlayer(Database db, DBResultSet results, const char[] error, any data)
+public void SQL_CheckDeletePlayer(Database db, DBResultSet results, const char[] error, DataPack data)
 {
-	DataPack dp = view_as<DataPack>(data);
-	dp.Reset();
-	int client = dp.ReadCell();
+	data.Reset();
+	int client = data.ReadCell();
 	char sTarget[64];
-	dp.ReadString(sTarget, sizeof(sTarget));
-	int iTarget = dp.ReadCell();
-	delete dp;
+	data.ReadString(sTarget, sizeof(sTarget));
+	int iTarget = data.ReadCell();
+	delete data;
 	
 	if(results == null)
 	{
@@ -1525,13 +1524,12 @@ public void SQL_CheckDeletePlayer(Database db, DBResultSet results, const char[]
 	
 }
 
-public void SQL_MassDeleteItem(Database db, DBResultSet results, const char[] error, any data)
+public void SQL_MassDeleteItem(Database db, DBResultSet results, const char[] error, DataPack data)
 {
-	DataPack dp = view_as<DataPack>(data);
-	dp.Reset();
-	int client = dp.ReadCell();
-	int iIndex = dp.ReadCell();
-	delete dp;
+	data.Reset();
+	int client = data.ReadCell();
+	int iIndex = data.ReadCell();
+	delete data;
 	
 	int upgrade[InternalUpgradeInfo];
 	GetUpgradeByIndex(iIndex, upgrade);
@@ -1615,17 +1613,16 @@ public void SQL_MassDeleteItem(Database db, DBResultSet results, const char[] er
 	}
 }
 
-public void SQL_PrintPlayerStats(Database db, DBResultSet results, const char[] error, any data)
+public void SQL_PrintPlayerStats(Database db, DBResultSet results, const char[] error, DataPack data)
 {
-	DataPack dp = view_as<DataPack>(data);
-	dp.Reset();
-	int client = GetClientFromSerial(dp.ReadCell());
-	ReplySource source = view_as<ReplySource>(dp.ReadCell());
+	data.Reset();
+	int client = GetClientFromSerial(data.ReadCell());
+	ReplySource source = view_as<ReplySource>(data.ReadCell());
 	
 	if(results == null)
 	{
 		LogError("Error getting player stats in smrpg_db_stats: %s", error);
-		delete dp;
+		delete data;
 		return;
 	}
 
@@ -1643,18 +1640,17 @@ public void SQL_PrintPlayerStats(Database db, DBResultSet results, const char[] 
 	g_hDatabase.Query(SQL_PrintUpgradeStats, sQuery, data);
 }
 
-public void SQL_PrintUpgradeStats(Database db, DBResultSet results, const char[] error, any data)
+public void SQL_PrintUpgradeStats(Database db, DBResultSet results, const char[] error, DataPack data)
 {
-	DataPack dp = view_as<DataPack>(data);
-	dp.Reset();
-	int serial = dp.ReadCell();
+	data.Reset();
+	int serial = data.ReadCell();
 	int client = GetClientFromSerial(serial);
-	ReplySource source = view_as<ReplySource>(dp.ReadCell());
+	ReplySource source = view_as<ReplySource>(data.ReadCell());
 	
 	if(results == null)
 	{
 		LogError("Error getting upgrade names in smrpg_db_stats: %s", error);
-		delete dp;
+		delete data;
 		return;
 	}
 	
@@ -1681,18 +1677,17 @@ public void SQL_PrintUpgradeStats(Database db, DBResultSet results, const char[]
 		Format(sQuery, sizeof(sQuery), "SELECT COUNT(*), AVG(purchasedlevel) FROM %s WHERE upgrade_id = %d AND purchasedlevel > 0", TBL_PLAYERUPGRADES, results.FetchInt(0));
 		g_hDatabase.Query(SQL_PrintUpgradeUsage, sQuery, hPack);
 	}
-	delete dp;
+	delete data;
 }
 
-public void SQL_PrintUpgradeUsage(Database db, DBResultSet results, const char[] error, any data)
+public void SQL_PrintUpgradeUsage(Database db, DBResultSet results, const char[] error, DataPack data)
 {
-	DataPack dp = view_as<DataPack>(data);
-	dp.Reset();
-	int client = GetClientFromSerial(dp.ReadCell());
-	ReplySource source = view_as<ReplySource>(dp.ReadCell());
+	data.Reset();
+	int client = GetClientFromSerial(data.ReadCell());
+	ReplySource source = view_as<ReplySource>(data.ReadCell());
 	char sUpgradeName[MAX_UPGRADE_SHORTNAME_LENGTH];
-	dp.ReadString(sUpgradeName, sizeof(sUpgradeName));
-	delete dp;
+	data.ReadString(sUpgradeName, sizeof(sUpgradeName));
+	delete data;
 	
 	if(results == null)
 	{

--- a/scripting/smrpg/smrpg_database.sp
+++ b/scripting/smrpg/smrpg_database.sp
@@ -16,8 +16,8 @@
 // How long to wait for a reconnect after a failed connection attempt to the database?
 #define RECONNECT_INTERVAL 360.0
 
-new Handle:g_hDatabase;
-new Handle:g_hReconnectTimer;
+Database g_hDatabase;
+Handle g_hReconnectTimer;
 
 enum DatabaseDriver {
 	Driver_None,
@@ -25,29 +25,29 @@ enum DatabaseDriver {
 	Driver_SQLite
 };
 
-new DatabaseDriver:g_DriverType;
+DatabaseDriver g_DriverType;
 
-RegisterDatabaseNatives()
+void RegisterDatabaseNatives()
 {
-	// native bool:SMRPG_ResetAllPlayers(const String:sReason[], bool:bHardReset=false);
+	// native bool SMRPG_ResetAllPlayers(const char[] sReason, bool bHardReset=false);
 	CreateNative("SMRPG_ResetAllPlayers", Native_ResetAllPlayers);
-	// native SMRPG_FlushDatabase();
+	// native void SMRPG_FlushDatabase();
 	CreateNative("SMRPG_FlushDatabase", Native_FlushDatabase);
 }
 
-InitDatabase()
+void InitDatabase()
 {
 	ClearHandle(g_hReconnectTimer);
 	
 	if(SQL_CheckConfig(SMRPG_DB))
-		SQL_TConnect(SQL_OnConnect, SMRPG_DB);
+		Database.Connect(SQL_OnConnect, SMRPG_DB);
 	else
-		SQL_TConnect(SQL_OnConnect, "default"); // Default to 'default' section in the databases.cfg.
+		Database.Connect(SQL_OnConnect, "default"); // Default to 'default' section in the databases.cfg.
 }
 
-public SQL_OnConnect(Handle:owner, Handle:hndl, const String:error[], any:data)
+public void SQL_OnConnect(Database db, const char[] error, any data)
 {
-	if(hndl == INVALID_HANDLE)
+	if(db == null)
 	{
 		LogError("Error connecting to database (reconnecting in %.0f seconds): %s", RECONNECT_INTERVAL, error);
 		ClearHandle(g_hReconnectTimer);
@@ -58,16 +58,17 @@ public SQL_OnConnect(Handle:owner, Handle:hndl, const String:error[], any:data)
 	// We're good now. Don't reconnect again. Just to be sure.
 	ClearHandle(g_hReconnectTimer);
 	
-	g_hDatabase = hndl;
+	g_hDatabase = db;
 	
-	new String:sDriverIdent[16];
-	SQL_GetDriverIdent(owner, sDriverIdent, sizeof(sDriverIdent));
+	DBDriver driver = db.Driver;
+	char sDriverIdent[16];
+	driver.GetIdentifier(sDriverIdent, sizeof(sDriverIdent));
 	
 	// Set the right character set in mysql
 	if(StrEqual(sDriverIdent, "mysql", false))
 	{
 		g_DriverType = Driver_MySQL;
-		SQL_SetCharset(g_hDatabase, "utf8");
+		g_hDatabase.SetCharset("utf8");
 	}
 	else if(StrEqual(sDriverIdent, "sqlite", false))
 	{
@@ -79,18 +80,18 @@ public SQL_OnConnect(Handle:owner, Handle:hndl, const String:error[], any:data)
 	}
 	
 	// Make sure the tables are created using the correct charset, if the database was created with something else than utf8 as default.
-	new String:sDefaultCharset[32];
+	char sDefaultCharset[32];
 	if(g_DriverType == Driver_MySQL)
 	{
 		strcopy(sDefaultCharset, sizeof(sDefaultCharset), " DEFAULT CHARSET=utf8");
 	}
 	
 	// Create the player table
-	decl String:sQuery[1024];
+	char sQuery[1024];
 	Format(sQuery, sizeof(sQuery), "CREATE TABLE IF NOT EXISTS %s (player_id INTEGER PRIMARY KEY %s, name VARCHAR(64) NOT NULL DEFAULT ' ', steamid INTEGER DEFAULT NULL UNIQUE, level INTEGER DEFAULT 1, experience INTEGER DEFAULT 0, credits INTEGER DEFAULT 0, showmenu INTEGER DEFAULT 1, fadescreen INTEGER DEFAULT 1, lastseen INTEGER DEFAULT 0, lastreset INTEGER DEFAULT 0)%s", TBL_PLAYERS, (g_DriverType == Driver_MySQL ? "AUTO_INCREMENT" : "AUTOINCREMENT"), sDefaultCharset);
 	if(!SQL_LockedFastQuery(g_hDatabase, sQuery))
 	{
-		decl String:sError[256];
+		char sError[256];
 		SQL_GetError(g_hDatabase, sError, sizeof(sError));
 		SetFailState("Error creating %s table: %s", TBL_PLAYERS, sError);
 		return;
@@ -100,7 +101,7 @@ public SQL_OnConnect(Handle:owner, Handle:hndl, const String:error[], any:data)
 	Format(sQuery, sizeof(sQuery), "CREATE TABLE IF NOT EXISTS %s (player_id INTEGER, upgrade_id INTEGER, purchasedlevel INTEGER NOT NULL, selectedlevel INTEGER NOT NULL, enabled INTEGER DEFAULT 1, visuals INTEGER DEFAULT 1, sounds INTEGER DEFAULT 1, PRIMARY KEY(player_id, upgrade_id))%s", TBL_PLAYERUPGRADES, sDefaultCharset);
 	if(!SQL_LockedFastQuery(g_hDatabase, sQuery))
 	{
-		decl String:sError[256];
+		char sError[256];
 		SQL_GetError(g_hDatabase, sError, sizeof(sError));
 		SetFailState("Error creating %s table: %s", TBL_PLAYERUPGRADES, sError);
 		return;
@@ -110,7 +111,7 @@ public SQL_OnConnect(Handle:owner, Handle:hndl, const String:error[], any:data)
 	Format(sQuery, sizeof(sQuery), "CREATE TABLE IF NOT EXISTS %s (upgrade_id INTEGER PRIMARY KEY %s, shortname VARCHAR(32) UNIQUE NOT NULL, date_added INTEGER)%s", TBL_UPGRADES, (g_DriverType == Driver_MySQL ? "AUTO_INCREMENT" : "AUTOINCREMENT"), sDefaultCharset);
 	if(!SQL_LockedFastQuery(g_hDatabase, sQuery))
 	{
-		decl String:sError[256];
+		char sError[256];
 		SQL_GetError(g_hDatabase, sError, sizeof(sError));
 		SetFailState("Error creating %s table: %s", TBL_UPGRADES, sError);
 		return;
@@ -120,7 +121,7 @@ public SQL_OnConnect(Handle:owner, Handle:hndl, const String:error[], any:data)
 	Format(sQuery, sizeof(sQuery), "CREATE TABLE IF NOT EXISTS %s (setting VARCHAR(64) PRIMARY KEY NOT NULL, value VARCHAR(256) NOT NULL)%s", TBL_SETTINGS, sDefaultCharset);
 	if(!SQL_LockedFastQuery(g_hDatabase, sQuery))
 	{
-		decl String:sError[256];
+		char sError[256];
 		SQL_GetError(g_hDatabase, sError, sizeof(sError));
 		SetFailState("Error creating %s table: %s", TBL_SETTINGS, sError);
 		return;
@@ -130,9 +131,9 @@ public SQL_OnConnect(Handle:owner, Handle:hndl, const String:error[], any:data)
 
 	// This is probably empty since no upgrades could have registered yet, but well..
 	// Add all columns for currently loaded upgrades.
-	new iSize = GetUpgradeCount();
-	new upgrade[InternalUpgradeInfo];
-	for(new i=0;i<iSize;i++)
+	int iSize = GetUpgradeCount();
+	int upgrade[InternalUpgradeInfo];
+	for(int i=0;i<iSize;i++)
 	{
 		GetUpgradeByIndex(i, upgrade);
 		if(!IsValidUpgrade(upgrade) || upgrade[UPGR_databaseId] != -1 || upgrade[UPGR_databaseLoading])
@@ -144,7 +145,7 @@ public SQL_OnConnect(Handle:owner, Handle:hndl, const String:error[], any:data)
 	DatabaseMaid();
 	
 	// Add all already connected players now
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i) && !IsFakeClient(i) && IsClientAuthorized(i))
 		{
@@ -153,15 +154,15 @@ public SQL_OnConnect(Handle:owner, Handle:hndl, const String:error[], any:data)
 	}
 }
 
-public Action:Timer_ReconnectDatabase(Handle:timer)
+public Action Timer_ReconnectDatabase(Handle timer)
 {
 	// Try to connect again after it first failed on plugin load.
-	g_hReconnectTimer = INVALID_HANDLE;
+	g_hReconnectTimer = null;
 	InitDatabase();
 	return Plugin_Stop;
 }
 
-CheckUpgradeDatabaseEntry(upgrade[InternalUpgradeInfo])
+void CheckUpgradeDatabaseEntry(int upgrade[InternalUpgradeInfo])
 {
 	if(!g_hDatabase)
 		return;
@@ -169,17 +170,17 @@ CheckUpgradeDatabaseEntry(upgrade[InternalUpgradeInfo])
 	upgrade[UPGR_databaseLoading] = true;
 	SaveUpgradeConfig(upgrade);
 	
-	decl String:sQuery[512];
+	char sQuery[512];
 	// Check if that's a completely new upgrade
-	decl String:sShortNameEscaped[MAX_UPGRADE_SHORTNAME_LENGTH*2+1];
-	SQL_EscapeString(g_hDatabase, upgrade[UPGR_shortName], sShortNameEscaped, sizeof(sShortNameEscaped));
+	char sShortNameEscaped[MAX_UPGRADE_SHORTNAME_LENGTH*2+1];
+	g_hDatabase.Escape(upgrade[UPGR_shortName], sShortNameEscaped, sizeof(sShortNameEscaped));
 	Format(sQuery, sizeof(sQuery), "SELECT upgrade_id FROM %s WHERE shortname = \"%s\";", TBL_UPGRADES, sShortNameEscaped);
-	SQL_TQuery(g_hDatabase, SQL_GetUpgradeInfo, sQuery, upgrade[UPGR_index]);
+	g_hDatabase.Query(SQL_GetUpgradeInfo, sQuery, upgrade[UPGR_index]);
 }
 
-CheckDatabaseVersion()
+void CheckDatabaseVersion()
 {
-	decl String:sValue[8];
+	char sValue[8];
 	if(!GetSetting("version", sValue, sizeof(sValue)))
 	{
 		// There is no version field yet? Just create one, we don't know if we'd need to update something..
@@ -188,7 +189,7 @@ CheckDatabaseVersion()
 		return;
 	}
 	
-	new iVersion = StringToInt(sValue);
+	int iVersion = StringToInt(sValue);
 	if(iVersion < DATABASE_VERSION)
 	{
 		// Perform database updates here..
@@ -197,7 +198,7 @@ CheckDatabaseVersion()
 			if(g_DriverType == Driver_MySQL)
 			{
 				// Save steamids as accountid integers instead of STEAM_X:Y:Z
-				decl String:sQuery[512];
+				char sQuery[512];
 				// Allow NULL as steamid value
 				Format(sQuery, sizeof(sQuery), "ALTER TABLE %s CHANGE steamid steamid VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_general_ci NULL", TBL_PLAYERS);
 				if(!SQL_LockedFastQuery(g_hDatabase, sQuery))
@@ -233,7 +234,7 @@ CheckDatabaseVersion()
 			else if(g_DriverType == Driver_SQLite)
 			{
 				// Save steamids as accountid integers instead of STEAM_X:Y:Z
-				decl String:sQuery[512];
+				char sQuery[512];
 				// Create a new table with the changed steamid field.
 				// SQLite doesn't support altering column types of existing tables.
 				Format(sQuery, sizeof(sQuery), "CREATE TABLE %s_X (player_id INTEGER PRIMARY KEY AUTOINCREMENT, name VARCHAR(64) NOT NULL DEFAULT ' ', steamid INTEGER DEFAULT NULL UNIQUE, level INTEGER DEFAULT 1, experience INTEGER DEFAULT 0, credits INTEGER DEFAULT 0, showmenu INTEGER DEFAULT 1, fadescreen INTEGER DEFAULT 1, lastseen INTEGER DEFAULT 0, lastreset INTEGER DEFAULT 0);", TBL_PLAYERS);
@@ -287,32 +288,32 @@ CheckDatabaseVersion()
 	}
 }
 
-FailDatabaseUpdateError(iVersion, const String:sQuery[])
+void FailDatabaseUpdateError(int iVersion, const char[] sQuery)
 {
-	decl String:sError[256];
+	char sError[256];
 	SQL_GetError(g_hDatabase, sError, sizeof(sError));
 	SetFailState("Failed to update the database to version %d. The plugin might not run correctly. Query: %s    Error: %s", iVersion, sQuery, sError);
 }
 
-DatabaseMaid()
+void DatabaseMaid()
 {
 	if(!g_hDatabase)
 		return;
 	
 	// Don't touch the database, if we don't want to save any data.
-	if(!GetConVarBool(g_hCVSaveData))
+	if(!g_hCVSaveData.BoolValue)
 		return;
 	
-	new String:sQuery[256];
+	char sQuery[256];
 	// Have players expire after x days and delete them from the database?
-	if(GetConVarInt(g_hCVPlayerExpire) > 0)
+	if(g_hCVPlayerExpire.IntValue > 0)
 	{
-		Format(sQuery, sizeof(sQuery), "OR lastseen <= %d", GetTime()-(86400*GetConVarInt(g_hCVPlayerExpire)));
+		Format(sQuery, sizeof(sQuery), "OR lastseen <= %d", GetTime()-(86400*g_hCVPlayerExpire.IntValue));
 	}
 	
 	// Delete players who are Level 1 and haven't played for 3 days
 	Format(sQuery, sizeof(sQuery), "SELECT player_id FROM %s WHERE (level <= 1 AND lastseen <= %d) %s", TBL_PLAYERS, GetTime()-259200, sQuery);
-	SQL_TQuery(g_hDatabase, SQL_DeleteExpiredPlayers, sQuery);
+	g_hDatabase.Query(SQL_DeleteExpiredPlayers, sQuery);
 	
 	// Reduce sqlite database file size.
 	if(g_DriverType == Driver_SQLite)
@@ -323,33 +324,33 @@ DatabaseMaid()
 }
 
 // Natives
-public Native_ResetAllPlayers(Handle:plugin, numParams)
+public int Native_ResetAllPlayers(Handle plugin, int numParams)
 {
 	if(!g_hDatabase)
 		return false;
 	
 	// Don't touch the database, if we don't want to save any data.
-	if(!GetConVarBool(g_hCVSaveData))
+	if(!g_hCVSaveData.BoolValue)
 		return false;
 	
-	new String:sReason[256];
+	char sReason[256];
 	GetNativeString(1, sReason, sizeof(sReason));
 	
-	new bool:bHardReset = bool:GetNativeCell(2);
-	decl String:sQuery[512];
+	bool bHardReset = view_as<bool>(GetNativeCell(2));
+	char sQuery[512];
 
 	// Delete all player information?
 	if(bHardReset)
 	{
-		new Transaction:hTransaction = SQL_CreateTransaction();
+		Transaction hTransaction = new Transaction();
 		Format(sQuery, sizeof(sQuery), "DELETE FROM %s", TBL_PLAYERUPGRADES);
-		SQL_AddQuery(hTransaction, sQuery);
+		hTransaction.AddQuery(sQuery);
 		Format(sQuery, sizeof(sQuery), "DELETE FROM %s", TBL_PLAYERS);
-		SQL_AddQuery(hTransaction, sQuery);
-		SQL_ExecuteTransaction(g_hDatabase, hTransaction, _, SQLTxn_LogFailure);
+		hTransaction.AddQuery(sQuery);
+		g_hDatabase.Execute(hTransaction, _, SQLTxn_LogFailure);
 		
 		// Reset all ingame players and readd them into the database.
-		for(new i=1;i<=MaxClients;i++)
+		for(int i=1;i<=MaxClients;i++)
 		{
 			if(IsClientInGame(i))
 			{
@@ -363,15 +364,15 @@ public Native_ResetAllPlayers(Handle:plugin, numParams)
 	// Keep the player settings
 	else
 	{
-		new Transaction:hTransaction = SQL_CreateTransaction();
-		Format(sQuery, sizeof(sQuery), "UPDATE %s SET level = 1, experience = 0, credits = %d, lastreset = %d", TBL_PLAYERS, GetConVarInt(g_hCVCreditsStart), GetTime());
-		SQL_AddQuery(hTransaction, sQuery);
+		Transaction hTransaction = new Transaction();
+		Format(sQuery, sizeof(sQuery), "UPDATE %s SET level = 1, experience = 0, credits = %d, lastreset = %d", TBL_PLAYERS, g_hCVCreditsStart.IntValue, GetTime());
+		hTransaction.AddQuery(sQuery);
 		Format(sQuery, sizeof(sQuery), "UPDATE %s SET purchasedlevel = 0, selectedlevel = 0, enabled = 1", TBL_PLAYERUPGRADES);
-		SQL_AddQuery(hTransaction, sQuery);
-		SQL_ExecuteTransaction(g_hDatabase, hTransaction, _, SQLTxn_LogFailure);
+		hTransaction.AddQuery(sQuery);
+		g_hDatabase.Execute(hTransaction, _, SQLTxn_LogFailure);
 		
 		// Just reset all ingame players too
-		for(new i=1;i<=MaxClients;i++)
+		for(int i=1;i<=MaxClients;i++)
 		{
 			if(IsClientInGame(i))
 			{
@@ -391,107 +392,109 @@ public Native_ResetAllPlayers(Handle:plugin, numParams)
 	return true;
 }
 
-public Native_FlushDatabase(Handle:plugin, numParams)
+public int Native_FlushDatabase(Handle plugin, int numParams)
 {
 	// Flush all info into the database. This handles smrpg_save_data and smrpg_enable
 	SaveAllPlayers();
 }
 
-public SQL_DoNothing(Handle:owner, Handle:hndl, const String:error[], any:data)
+public void SQL_DoNothing(Database db, DBResultSet results, const char[] error, any data)
 {
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Error executing query: %s", error);
 	}
 }
 
-public SQLTxn_LogFailure(Handle:db, any:data, numQueries, const String:error[], failIndex, any:queryData[])
+public void SQLTxn_LogFailure(Database db, any data, int numQueries, const char[] error, int failIndex, any[] queryData)
 {
 	LogError("Error executing query %d of %d queries: %s", failIndex, numQueries, error);
 }
 
-public SQL_GetUpgradeInfo(Handle:owner, Handle:hndl, const String:error[], any:index)
+public void SQL_GetUpgradeInfo(Database db, DBResultSet results, const char[] error, any index)
 {
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Error checking for upgrade info: %s", error);
 		return;
 	}
 	
-	new upgrade[InternalUpgradeInfo];
+	int upgrade[InternalUpgradeInfo];
 	GetUpgradeByIndex(index, upgrade);
 	
-	decl String:sQuery[256];
+	char sQuery[256];
 	// This is a new upgrade!
-	if(!SQL_GetRowCount(hndl) || !SQL_FetchRow(hndl))
+	if(!results.RowCount || !results.FetchRow())
 	{
 		Format(sQuery, sizeof(sQuery), "INSERT INTO %s (shortname, date_added) VALUES (\"%s\", %d);", TBL_UPGRADES, upgrade[UPGR_shortName], GetTime());
-		SQL_TQuery(g_hDatabase, SQL_InsertNewUpgrade, sQuery, index);
+		g_hDatabase.Query(SQL_InsertNewUpgrade, sQuery, index);
 		return;
 	}
 	
 	upgrade[UPGR_databaseLoading] = false;
-	upgrade[UPGR_databaseId] = SQL_FetchInt(hndl, 0);
+	upgrade[UPGR_databaseId] = results.FetchInt(0);
 	SaveUpgradeConfig(upgrade);
 	
 	// Load the data for all connected players
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i) && IsClientAuthorized(i) && GetClientDatabaseId(i) != -1)
 		{
 			Format(sQuery, sizeof(sQuery), "SELECT upgrade_id, purchasedlevel, selectedlevel, enabled, visuals, sounds FROM %s WHERE player_id = %d AND upgrade_id = %d", TBL_PLAYERUPGRADES, GetClientDatabaseId(i), upgrade[UPGR_databaseId]);
-			SQL_TQuery(g_hDatabase, SQL_GetPlayerUpgrades, sQuery, GetClientUserId(i));
+			g_hDatabase.Query(SQL_GetPlayerUpgrades, sQuery, GetClientUserId(i));
 		}
 	}
 }
 
-public SQL_InsertNewUpgrade(Handle:owner, Handle:hndl, const String:error[], any:index)
+public void SQL_InsertNewUpgrade(Database db, DBResultSet results, const char[] error, any index)
 {
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Error inserting new upgrade info: %s", error);
 		return;
 	}
 	
-	new upgrade[InternalUpgradeInfo];
+	int upgrade[InternalUpgradeInfo];
 	GetUpgradeByIndex(index, upgrade);
 	
 	upgrade[UPGR_databaseLoading] = false;
-	upgrade[UPGR_databaseId] = SQL_GetInsertId(owner);
+	upgrade[UPGR_databaseId] = results.InsertId;
 	SaveUpgradeConfig(upgrade);
 }
 
 // Delete all players which weren't seen on the server for too a long time.
-public SQL_DeleteExpiredPlayers(Handle:owner, Handle:hndl, const String:error[], any:data)
+public void SQL_DeleteExpiredPlayers(Database db, DBResultSet results, const char[] error, any data)
 {
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("DatabaseMaid: player expire query failed: %s", error);
+		return;
 	}
 	
 	// Delete them at once.
-	new Transaction:hTransaction = SQL_CreateTransaction();
+	Transaction hTransaction = new Transaction();
 	
-	new iPlayerId, String:sQuery[128];
-	while(SQL_MoreRows(hndl))
+	int iPlayerId;
+	char sQuery[128];
+	while(results.MoreRows)
 	{
-		if(!SQL_FetchRow(hndl))
+		if(!results.FetchRow())
 			continue;
 		
-		iPlayerId = SQL_FetchInt(hndl, 0);
+		iPlayerId = results.FetchInt(0);
 		
 		// Don't delete players who are connected right now.
 		if (GetClientByPlayerID(iPlayerId) != -1)
 			continue;
 		
 		Format(sQuery, sizeof(sQuery), "DELETE FROM %s WHERE player_id = %d", TBL_PLAYERUPGRADES, iPlayerId);
-		SQL_AddQuery(hTransaction, sQuery);
+		hTransaction.AddQuery(sQuery);
 		
 		Format(sQuery, sizeof(sQuery), "DELETE FROM %s WHERE player_id = %d", TBL_PLAYERS, iPlayerId);
-		SQL_AddQuery(hTransaction, sQuery);
+		hTransaction.AddQuery(sQuery);
 	}
 	
-	SQL_ExecuteTransaction(g_hDatabase, hTransaction, _, SQLTxn_LogFailure);
+	g_hDatabase.Execute(hTransaction, _, SQLTxn_LogFailure);
 }
 
 /**
@@ -507,10 +510,10 @@ public SQL_DeleteExpiredPlayers(Handle:owner, Handle:hndl, const String:error[],
  *						SQL_GetError to find the last error.
  * @error				Invalid database Handle.
  */
-stock bool:SQL_LockedFastQuery(Handle:database, const String:query[], len=-1)
+stock bool SQL_LockedFastQuery(Database database, const char[] query, int len=-1)
 {
 	SQL_LockDatabase(database);
-	new bool:bSuccess = SQL_FastQuery(database, query, len);
+	bool bSuccess = SQL_FastQuery(database, query, len);
 	SQL_UnlockDatabase(database);
 	return bSuccess;
 }

--- a/scripting/smrpg/smrpg_menu.sp
+++ b/scripting/smrpg/smrpg_menu.sp
@@ -2,102 +2,102 @@
 #include <sourcemod>
 #include <topmenus>
 
-new Handle:g_hRPGTopMenu;
+TopMenu g_hRPGTopMenu;
 
-new TopMenuObject:g_TopMenuUpgrades;
-new TopMenuObject:g_TopMenuSell;
-new TopMenuObject:g_TopMenuUpgradeSettings;
-new TopMenuObject:g_TopMenuStats;
-new TopMenuObject:g_TopMenuSettings;
-new TopMenuObject:g_TopMenuHelp;
+TopMenuObject g_TopMenuUpgrades;
+TopMenuObject g_TopMenuSell;
+TopMenuObject g_TopMenuUpgradeSettings;
+TopMenuObject g_TopMenuStats;
+TopMenuObject g_TopMenuSettings;
+TopMenuObject g_TopMenuHelp;
 
-new Handle:g_hConfirmResetStatsMenu;
+Menu g_hConfirmResetStatsMenu;
 
-new Handle:g_hfwdOnRPGMenuCreated;
-new Handle:g_hfwdOnRPGMenuReady;
+Handle g_hfwdOnRPGMenuCreated;
+Handle g_hfwdOnRPGMenuReady;
 
-new g_iSelectedSettingsUpgrade[MAXPLAYERS+1] = {-1,...};
+int g_iSelectedSettingsUpgrade[MAXPLAYERS+1] = {-1,...};
 
 /**
  * Setup functions to create the topmenu and API.
  */
-RegisterTopMenu()
+void RegisterTopMenu()
 {
-	g_hRPGTopMenu = CreateTopMenu(TopMenu_DefaultCategoryHandler);
-	SetTopMenuTitleCaching(g_hRPGTopMenu, false);
+	g_hRPGTopMenu = new TopMenu(TopMenu_DefaultCategoryHandler);
+	g_hRPGTopMenu.CacheTitles = false;
 	
-	g_TopMenuUpgrades = AddToTopMenu(g_hRPGTopMenu, RPGMENU_UPGRADES, TopMenuObject_Category, TopMenu_DefaultCategoryHandler, INVALID_TOPMENUOBJECT);
-	g_TopMenuSell = AddToTopMenu(g_hRPGTopMenu, RPGMENU_SELL, TopMenuObject_Category, TopMenu_DefaultCategoryHandler, INVALID_TOPMENUOBJECT);
-	g_TopMenuUpgradeSettings = AddToTopMenu(g_hRPGTopMenu, RPGMENU_UPGRADESETTINGS, TopMenuObject_Category, TopMenu_DefaultCategoryHandler, INVALID_TOPMENUOBJECT);
-	g_TopMenuStats = AddToTopMenu(g_hRPGTopMenu, RPGMENU_STATS, TopMenuObject_Category, TopMenu_DefaultCategoryHandler, INVALID_TOPMENUOBJECT);
-	g_TopMenuSettings = AddToTopMenu(g_hRPGTopMenu, RPGMENU_SETTINGS, TopMenuObject_Category, TopMenu_DefaultCategoryHandler, INVALID_TOPMENUOBJECT);
-	g_TopMenuHelp = AddToTopMenu(g_hRPGTopMenu, RPGMENU_HELP, TopMenuObject_Category, TopMenu_DefaultCategoryHandler, INVALID_TOPMENUOBJECT);
+	g_TopMenuUpgrades = g_hRPGTopMenu.AddCategory(RPGMENU_UPGRADES, TopMenu_DefaultCategoryHandler);
+	g_TopMenuSell = g_hRPGTopMenu.AddCategory(RPGMENU_SELL, TopMenu_DefaultCategoryHandler);
+	g_TopMenuUpgradeSettings = g_hRPGTopMenu.AddCategory(RPGMENU_UPGRADESETTINGS, TopMenu_DefaultCategoryHandler);
+	g_TopMenuStats = g_hRPGTopMenu.AddCategory(RPGMENU_STATS, TopMenu_DefaultCategoryHandler);
+	g_TopMenuSettings = g_hRPGTopMenu.AddCategory(RPGMENU_SETTINGS, TopMenu_DefaultCategoryHandler);
+	g_TopMenuHelp = g_hRPGTopMenu.AddCategory(RPGMENU_HELP, TopMenu_DefaultCategoryHandler);
 }
 
-RegisterTopMenuForwards()
+void RegisterTopMenuForwards()
 {
 	g_hfwdOnRPGMenuCreated = CreateGlobalForward("SMRPG_OnRPGMenuCreated", ET_Ignore, Param_Cell);
 	g_hfwdOnRPGMenuReady = CreateGlobalForward("SMRPG_OnRPGMenuReady", ET_Ignore, Param_Cell);
 }
 
-RegisterTopMenuNatives()
+void RegisterTopMenuNatives()
 {
 	CreateNative("SMRPG_GetTopMenu", Native_GetTopMenu);
 }
 
-InitMenu()
+void InitMenu()
 {
 	// Add any already loaded upgrades to the menus
-	new iSize = GetUpgradeCount();
-	new upgrade[InternalUpgradeInfo];
-	decl String:sBuffer[MAX_UPGRADE_SHORTNAME_LENGTH+20];
-	for(new i=0;i<iSize;i++)
+	int iSize = GetUpgradeCount();
+	int upgrade[InternalUpgradeInfo];
+	char sBuffer[MAX_UPGRADE_SHORTNAME_LENGTH+20];
+	for(int i=0;i<iSize;i++)
 	{
 		GetUpgradeByIndex(i, upgrade);
 		
 		if(upgrade[UPGR_topmenuUpgrades] == INVALID_TOPMENUOBJECT)
 		{
 			Format(sBuffer, sizeof(sBuffer), "rpgupgrade_%s", upgrade[UPGR_shortName]);
-			upgrade[UPGR_topmenuUpgrades] = AddToTopMenu(g_hRPGTopMenu, sBuffer, TopMenuObject_Item, TopMenu_HandleUpgrades, g_TopMenuUpgrades);
+			upgrade[UPGR_topmenuUpgrades] = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleUpgrades, g_TopMenuUpgrades);
 		}
 		if(upgrade[UPGR_topmenuSell] == INVALID_TOPMENUOBJECT)
 		{
 			Format(sBuffer, sizeof(sBuffer), "rpgsell_%s", upgrade[UPGR_shortName]);
-			upgrade[UPGR_topmenuSell] = AddToTopMenu(g_hRPGTopMenu, sBuffer, TopMenuObject_Item, TopMenu_HandleSell, g_TopMenuSell);
+			upgrade[UPGR_topmenuSell] = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleSell, g_TopMenuSell);
 		}
 		if(upgrade[UPGR_topmenuUpgradeSettings] == INVALID_TOPMENUOBJECT)
 		{
 			Format(sBuffer, sizeof(sBuffer), "rpgupgrsettings_%s", upgrade[UPGR_shortName]);
-			upgrade[UPGR_topmenuUpgradeSettings] = AddToTopMenu(g_hRPGTopMenu, sBuffer, TopMenuObject_Item, TopMenu_HandleUpgradeSettings, g_TopMenuUpgradeSettings);
+			upgrade[UPGR_topmenuUpgradeSettings] = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleUpgradeSettings, g_TopMenuUpgradeSettings);
 		}
 		if(upgrade[UPGR_topmenuHelp] == INVALID_TOPMENUOBJECT)
 		{
 			Format(sBuffer, sizeof(sBuffer), "rpghelp_%s", upgrade[UPGR_shortName]);
-			upgrade[UPGR_topmenuHelp] = AddToTopMenu(g_hRPGTopMenu, sBuffer, TopMenuObject_Item, TopMenu_HandleHelp, g_TopMenuHelp);
+			upgrade[UPGR_topmenuHelp] = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleHelp, g_TopMenuHelp);
 		}
 		SaveUpgradeConfig(upgrade);
 	}
 	
 	// Stats Menu
-	AddToTopMenu(g_hRPGTopMenu, "level", TopMenuObject_Item, TopMenu_HandleStats, g_TopMenuStats);
-	AddToTopMenu(g_hRPGTopMenu, "exp", TopMenuObject_Item, TopMenu_HandleStats, g_TopMenuStats);
-	AddToTopMenu(g_hRPGTopMenu, "credits", TopMenuObject_Item, TopMenu_HandleStats, g_TopMenuStats);
-	AddToTopMenu(g_hRPGTopMenu, "rank", TopMenuObject_Item, TopMenu_HandleStats, g_TopMenuStats);
-	AddToTopMenu(g_hRPGTopMenu, "lastexp", TopMenuObject_Item, TopMenu_HandleStats, g_TopMenuStats);
+	g_hRPGTopMenu.AddItem("level", TopMenu_HandleStats, g_TopMenuStats);
+	g_hRPGTopMenu.AddItem("exp", TopMenu_HandleStats, g_TopMenuStats);
+	g_hRPGTopMenu.AddItem("credits", TopMenu_HandleStats, g_TopMenuStats);
+	g_hRPGTopMenu.AddItem("rank", TopMenu_HandleStats, g_TopMenuStats);
+	g_hRPGTopMenu.AddItem("lastexp", TopMenu_HandleStats, g_TopMenuStats);
 	
 	// Settings Menu
-	AddToTopMenu(g_hRPGTopMenu, "resetstats", TopMenuObject_Item, TopMenu_HandleSettings, g_TopMenuSettings);
-	AddToTopMenu(g_hRPGTopMenu, "toggleautoshow", TopMenuObject_Item, TopMenu_HandleSettings, g_TopMenuSettings);
-	AddToTopMenu(g_hRPGTopMenu, "togglefade", TopMenuObject_Item, TopMenu_HandleSettings, g_TopMenuSettings);
+	g_hRPGTopMenu.AddItem("resetstats", TopMenu_HandleSettings, g_TopMenuSettings);
+	g_hRPGTopMenu.AddItem("toggleautoshow", TopMenu_HandleSettings, g_TopMenuSettings);
+	g_hRPGTopMenu.AddItem("togglefade", TopMenu_HandleSettings, g_TopMenuSettings);
 	
 	// Reset Stats Confirmation
-	g_hConfirmResetStatsMenu = CreateMenu(Menu_ConfirmResetStats, MENU_ACTIONS_DEFAULT|MenuAction_Display|MenuAction_DisplayItem);
-	SetMenuExitBackButton(g_hConfirmResetStatsMenu, true);
+	g_hConfirmResetStatsMenu = new Menu(Menu_ConfirmResetStats, MENU_ACTIONS_DEFAULT|MenuAction_Display|MenuAction_DisplayItem);
+	g_hConfirmResetStatsMenu.ExitBackButton = true;
 
-	SetMenuTitle(g_hConfirmResetStatsMenu, "credits_display");
+	g_hConfirmResetStatsMenu.SetTitle("credits_display");
 	
-	AddMenuItem(g_hConfirmResetStatsMenu, "yes", "Yes");
-	AddMenuItem(g_hConfirmResetStatsMenu, "no", "No");
+	g_hConfirmResetStatsMenu.AddItem("yes", "Yes");
+	g_hConfirmResetStatsMenu.AddItem("no", "No");
 	
 	Call_StartForward(g_hfwdOnRPGMenuCreated);
 	Call_PushCell(g_hRPGTopMenu);
@@ -108,7 +108,7 @@ InitMenu()
 	Call_Finish();
 }
 
-ResetPlayerMenu(client)
+void ResetPlayerMenu(int client)
 {
 	g_iSelectedSettingsUpgrade[client] = -1;
 }
@@ -116,26 +116,26 @@ ResetPlayerMenu(client)
 /**
  * Native callbacks
  */
-public Native_GetTopMenu(Handle:plugin, numParams)
+public int Native_GetTopMenu(Handle plugin, int numParams)
 {
-	return _:g_hRPGTopMenu;
+	return view_as<int>(g_hRPGTopMenu);
 }
 
-DisplayMainMenu(client)
+void DisplayMainMenu(int client)
 {
-	DisplayTopMenu(g_hRPGTopMenu, client, TopMenuPosition_Start);
+	g_hRPGTopMenu.Display(client, TopMenuPosition_Start);
 }
 
-DisplayUpgradesMenu(client)
+void DisplayUpgradesMenu(int client)
 {
-	DisplayTopMenuCategory(g_hRPGTopMenu, g_TopMenuUpgrades, client);
+	g_hRPGTopMenu.DisplayCategory(g_TopMenuUpgrades, client);
 }
 
 /**
  * TopMenu callback handlers
  */
 // Print the default categories correctly.
-public TopMenu_DefaultCategoryHandler(Handle:topmenu, TopMenuAction:action, TopMenuObject:object_id, param, String:buffer[], maxlength)
+public void TopMenu_DefaultCategoryHandler(TopMenu topmenu, TopMenuAction action, TopMenuObject object_id, int param, char[] buffer, int maxlength)
 {
 	switch(action)
 	{
@@ -162,16 +162,16 @@ public TopMenu_DefaultCategoryHandler(Handle:topmenu, TopMenuAction:action, TopM
 	}
 }
 
-public TopMenu_HandleUpgrades(Handle:topmenu, TopMenuAction:action, TopMenuObject:object_id, param, String:buffer[], maxlength)
+public void TopMenu_HandleUpgrades(TopMenu topmenu, TopMenuAction action, TopMenuObject object_id, int param, char[] buffer, int maxlength)
 {
 	switch(action)
 	{
 		case TopMenuAction_DisplayOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			if(!GetUpgradeByShortname(sShortname[11], upgrade))
 				return;
 			
@@ -179,22 +179,22 @@ public TopMenu_HandleUpgrades(Handle:topmenu, TopMenuAction:action, TopMenuObjec
 				return;
 			
 			// Show the team this upgrade is locked to, if it is.
-			new String:sTeamlock[128];
-			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && GetConVarBool(g_hCVShowTeamlockNoticeOwnTeam)) && upgrade[UPGR_teamlock] < GetTeamCount())
+			char sTeamlock[128];
+			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade[UPGR_teamlock] < GetTeamCount())
 			{
 				GetTeamName(upgrade[UPGR_teamlock], sTeamlock, sizeof(sTeamlock));
 				Format(sTeamlock, sizeof(sTeamlock), " (%T)", "Is teamlocked", param, sTeamlock);
 			}
 			
 			// Optionally show the maxlevel of the upgrade
-			new String:sMaxlevel[8];
-			if (GetConVarBool(g_hCVShowMaxLevelInMenu))
+			char sMaxlevel[8];
+			if (g_hCVShowMaxLevelInMenu.BoolValue)
 				Format(sMaxlevel, sizeof(sMaxlevel), "/%d", upgrade[UPGR_maxLevel]);
 			
-			decl String:sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
+			char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
 			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
 			
-			new iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
 			
 			if(iCurrentLevel >= upgrade[UPGR_maxLevel])
 			{
@@ -207,10 +207,10 @@ public TopMenu_HandleUpgrades(Handle:topmenu, TopMenuAction:action, TopMenuObjec
 		}
 		case TopMenuAction_DrawOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			// Don't show invalid upgrades at all in the menu.
 			if(!GetUpgradeByShortname(sShortname[11], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled] || !HasAccessToUpgrade(param, upgrade))
 			{
@@ -218,7 +218,7 @@ public TopMenu_HandleUpgrades(Handle:topmenu, TopMenuAction:action, TopMenuObjec
 				return;
 			}
 			
-			new iLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
 			// The upgrade is teamlocked and the client is in the wrong team.
 			if(!IsClientInLockedTeam(param, upgrade))
 			{
@@ -231,23 +231,23 @@ public TopMenu_HandleUpgrades(Handle:topmenu, TopMenuAction:action, TopMenuObjec
 		}
 		case TopMenuAction_SelectOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			
 			// Bad upgrade?
 			if(!GetUpgradeByShortname(sShortname[11], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled] || !HasAccessToUpgrade(param, upgrade))
 			{
-				DisplayTopMenu(g_hRPGTopMenu, param, TopMenuPosition_LastCategory);
+				g_hRPGTopMenu.Display(param, TopMenuPosition_LastCategory);
 				return;
 			}
 			
-			new iItemIndex = upgrade[UPGR_index];
-			new iItemLevel = GetClientPurchasedUpgradeLevel(param, iItemIndex);
-			new iCost = GetUpgradeCost(iItemIndex, iItemLevel+1);
+			int iItemIndex = upgrade[UPGR_index];
+			int iItemLevel = GetClientPurchasedUpgradeLevel(param, iItemIndex);
+			int iCost = GetUpgradeCost(iItemIndex, iItemLevel+1);
 			
-			new String:sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
+			char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
 			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
 			
 			if(iItemLevel >= upgrade[UPGR_maxLevel])
@@ -259,9 +259,9 @@ public TopMenu_HandleUpgrades(Handle:topmenu, TopMenuAction:action, TopMenuObjec
 				if(BuyClientUpgrade(param, iItemIndex))
 				{
 					Client_PrintToChat(param, false, "%t", "Upgrade bought", sTranslatedName, iItemLevel+1);
-					if(GetConVarBool(g_hCVShowUpgradePurchase))
+					if(g_hCVShowUpgradePurchase.BoolValue)
 					{
-						for(new i=1;i<=MaxClients;i++)
+						for(int i=1;i<=MaxClients;i++)
 						{
 							if(i != param && IsClientInGame(i) && !IsFakeClient(i))
 							{
@@ -273,21 +273,21 @@ public TopMenu_HandleUpgrades(Handle:topmenu, TopMenuAction:action, TopMenuObjec
 				}
 			}
 			
-			DisplayTopMenu(g_hRPGTopMenu, param, TopMenuPosition_LastCategory);
+			g_hRPGTopMenu.Display(param, TopMenuPosition_LastCategory);
 		}
 	}
 }
 
-public TopMenu_HandleSell(Handle:topmenu, TopMenuAction:action, TopMenuObject:object_id, param, String:buffer[], maxlength)
+public void TopMenu_HandleSell(TopMenu topmenu, TopMenuAction action, TopMenuObject object_id, int param, char[] buffer, int maxlength)
 {
 	switch(action)
 	{
 		case TopMenuAction_DisplayOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			if(!GetUpgradeByShortname(sShortname[8], upgrade))
 				return;
 			
@@ -295,29 +295,29 @@ public TopMenu_HandleSell(Handle:topmenu, TopMenuAction:action, TopMenuObject:ob
 				return;
 			
 			// Show the team this upgrade is locked to, if it is.
-			new String:sTeamlock[128];
-			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && GetConVarBool(g_hCVShowTeamlockNoticeOwnTeam)) && upgrade[UPGR_teamlock] < GetTeamCount())
+			char sTeamlock[128];
+			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade[UPGR_teamlock] < GetTeamCount())
 			{
 				GetTeamName(upgrade[UPGR_teamlock], sTeamlock, sizeof(sTeamlock));
 				Format(sTeamlock, sizeof(sTeamlock), " (%T)", "Is teamlocked", param, sTeamlock);
 			}
 			
 			// Optionally show the maxlevel of the upgrade
-			new String:sMaxlevel[8];
-			if (GetConVarBool(g_hCVShowMaxLevelInMenu))
+			char sMaxlevel[8];
+			if (g_hCVShowMaxLevelInMenu.BoolValue)
 				Format(sMaxlevel, sizeof(sMaxlevel), "/%d", upgrade[UPGR_maxLevel]);
 			
-			decl String:sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
+			char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
 			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
 			
 			Format(buffer, maxlength, "%s Lvl %d%s [%T: %d]%s", sTranslatedName, GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]), sMaxlevel, "Sale", param, GetUpgradeSale(upgrade[UPGR_index], GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index])), sTeamlock);
 		}
 		case TopMenuAction_DrawOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			// Don't show invalid upgrades at all in the menu.
 			if(!GetUpgradeByShortname(sShortname[8], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
 			{
@@ -325,7 +325,7 @@ public TopMenu_HandleSell(Handle:topmenu, TopMenuAction:action, TopMenuObject:ob
 				return;
 			}
 			
-			new iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
 			
 			// Allow clients to sell upgrades they no longer have access to, but don't show them, if they never bought it.
 			if(!HasAccessToUpgrade(param, upgrade) && iCurrentLevel <= 0)
@@ -346,73 +346,73 @@ public TopMenu_HandleSell(Handle:topmenu, TopMenuAction:action, TopMenuObject:ob
 		}
 		case TopMenuAction_SelectOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			
 			// Bad upgrade?
 			if(!GetUpgradeByShortname(sShortname[8], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
 			{
-				DisplayTopMenu(g_hRPGTopMenu, param, TopMenuPosition_LastCategory);
+				g_hRPGTopMenu.Display(param, TopMenuPosition_LastCategory);
 				return;
 			}
 			
-			new Handle:hMenu = CreateMenu(Menu_ConfirmSell, MENU_ACTIONS_DEFAULT|MenuAction_Display|MenuAction_DisplayItem);
-			SetMenuExitBackButton(hMenu, true);
+			Menu hMenu = new Menu(Menu_ConfirmSell, MENU_ACTIONS_DEFAULT|MenuAction_Display|MenuAction_DisplayItem);
+			hMenu.ExitBackButton = true;
 		
-			SetMenuTitle(hMenu, "credits_display");
+			hMenu.SetTitle("credits_display");
 			
-			decl String:sIndex[10];
+			char sIndex[10];
 			IntToString(upgrade[UPGR_index], sIndex, sizeof(sIndex));
-			AddMenuItem(hMenu, sIndex, "Yes");
-			AddMenuItem(hMenu, "no", "No");
+			hMenu.AddItem(sIndex, "Yes");
+			hMenu.AddItem("no", "No");
 			
-			DisplayMenu(hMenu, param, MENU_TIME_FOREVER);
+			hMenu.Display(param, MENU_TIME_FOREVER);
 		}
 	}
 }
 
-public Menu_ConfirmSell(Handle:menu, MenuAction:action, param1, param2)
+public int Menu_ConfirmSell(Menu menu, MenuAction action, int param1, int param2)
 {
 	if(action == MenuAction_Select)
 	{
-		decl String:sInfo[16];
-		GetMenuItem(menu, param2, sInfo, sizeof(sInfo));
+		char sInfo[16];
+		menu.GetItem(param2, sInfo, sizeof(sInfo));
 		
 		if(StrEqual(sInfo, "no"))
 			return 0;
 		
-		new iItemIndex = StringToInt(sInfo);
-		new upgrade[InternalUpgradeInfo];
+		int iItemIndex = StringToInt(sInfo);
+		int upgrade[InternalUpgradeInfo];
 		GetUpgradeByIndex(iItemIndex, upgrade);
 		SellClientUpgrade(param1, iItemIndex);
 		
-		new String:sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
+		char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
 		GetUpgradeTranslatedName(param1, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
 		Client_PrintToChat(param1, false, "%t", "Upgrade sold", sTranslatedName, GetClientPurchasedUpgradeLevel(param1, iItemIndex)+1);
 		
-		DisplayTopMenu(g_hRPGTopMenu, param1, TopMenuPosition_LastCategory);
+		g_hRPGTopMenu.Display(param1, TopMenuPosition_LastCategory);
 	}
 	else if(action == MenuAction_Display)
 	{
 		// Change the title
-		new Handle:hPanel = Handle:param2;
+		Panel hPanel = view_as<Panel>(param2);
 		
 		// Display the current credits in the title
-		decl String:sBuffer[256];
+		char sBuffer[256];
 		Format(sBuffer, sizeof(sBuffer), "%T\n-----\n%T\n", "Credits", param1, GetClientCredits(param1), "Are you sure?", param1);
 		
-		SetPanelTitle(hPanel, sBuffer);
+		hPanel.SetTitle(sBuffer);
 	}
 	else if(action == MenuAction_DisplayItem)
 	{
 		/* Get the display string, we'll use it as a translation phrase */
-		decl String:sDisplay[64];
-		GetMenuItem(menu, param2, "", 0, _, sDisplay, sizeof(sDisplay));
+		char sDisplay[64];
+		menu.GetItem(param2, "", 0, _, sDisplay, sizeof(sDisplay));
 
 		/* Translate the string to the client's language */
-		decl String:sBuffer[255];
+		char sBuffer[255];
 		Format(sBuffer, sizeof(sBuffer), "%T", sDisplay, param1);
 
 		/* Override the text */
@@ -421,25 +421,25 @@ public Menu_ConfirmSell(Handle:menu, MenuAction:action, param1, param2)
 	else if(action == MenuAction_Cancel)
 	{
 		if(param2 == MenuCancel_ExitBack)
-			DisplayTopMenu(g_hRPGTopMenu, param1, TopMenuPosition_LastCategory);
+			g_hRPGTopMenu.Display(param1, TopMenuPosition_LastCategory);
 	}
 	else if(action == MenuAction_End)
 	{
-		CloseHandle(menu);
+		delete menu;
 	}
 	return 0;
 }
 
-public TopMenu_HandleUpgradeSettings(Handle:topmenu, TopMenuAction:action, TopMenuObject:object_id, param, String:buffer[], maxlength)
+public void TopMenu_HandleUpgradeSettings(TopMenu topmenu, TopMenuAction action, TopMenuObject object_id, int param, char[] buffer, int maxlength)
 {
 	switch(action)
 	{
 		case TopMenuAction_DisplayOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			if(!GetUpgradeByShortname(sShortname[16], upgrade))
 				return;
 			
@@ -447,18 +447,18 @@ public TopMenu_HandleUpgradeSettings(Handle:topmenu, TopMenuAction:action, TopMe
 				return;
 			
 			// Show the team this upgrade is locked to, if it is.
-			new String:sTeamlock[128];
-			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && GetConVarBool(g_hCVShowTeamlockNoticeOwnTeam)) && upgrade[UPGR_teamlock] < GetTeamCount())
+			char sTeamlock[128];
+			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade[UPGR_teamlock] < GetTeamCount())
 			{
 				GetTeamName(upgrade[UPGR_teamlock], sTeamlock, sizeof(sTeamlock));
 				Format(sTeamlock, sizeof(sTeamlock), " (%T)", "Is teamlocked", param, sTeamlock);
 			}
 			
-			new iPurchasedLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
-			new iSelectedLevel = GetClientSelectedUpgradeLevel(param, upgrade[UPGR_index]);
-			decl String:sBuffer[128];
+			int iPurchasedLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iSelectedLevel = GetClientSelectedUpgradeLevel(param, upgrade[UPGR_index]);
+			char sBuffer[128];
 			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sBuffer, sizeof(sBuffer));
-			if(!GetConVarBool(g_hCVDisableLevelSelection))
+			if(!g_hCVDisableLevelSelection.BoolValue)
 				Format(sBuffer, sizeof(sBuffer), "%s Lvl %d/%d", sBuffer, iSelectedLevel, iPurchasedLevel);
 			
 			Format(sBuffer, sizeof(sBuffer), "%s [%T]%s", sBuffer, IsClientUpgradeEnabled(param, upgrade[UPGR_index])?"On":"Off", param, sTeamlock);
@@ -466,10 +466,10 @@ public TopMenu_HandleUpgradeSettings(Handle:topmenu, TopMenuAction:action, TopMe
 		}
 		case TopMenuAction_DrawOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			// Don't show invalid upgrades at all in the menu.
 			if(!GetUpgradeByShortname(sShortname[16], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
 			{
@@ -477,7 +477,7 @@ public TopMenu_HandleUpgradeSettings(Handle:topmenu, TopMenuAction:action, TopMe
 				return;
 			}
 			
-			new iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
 			
 			// Allow clients to view upgrades they no longer have access to, but don't show them, if they never bought it.
 			if(!HasAccessToUpgrade(param, upgrade) && iCurrentLevel <= 0)
@@ -496,15 +496,15 @@ public TopMenu_HandleUpgradeSettings(Handle:topmenu, TopMenuAction:action, TopMe
 		}
 		case TopMenuAction_SelectOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			
 			// Bad upgrade?
 			if(!GetUpgradeByShortname(sShortname[16], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
 			{
-				DisplayTopMenu(g_hRPGTopMenu, param, TopMenuPosition_LastCategory);
+				g_hRPGTopMenu.Display(param, TopMenuPosition_LastCategory);
 				return;
 			}
 			
@@ -513,65 +513,65 @@ public TopMenu_HandleUpgradeSettings(Handle:topmenu, TopMenuAction:action, TopMe
 	}
 }
 
-DisplayUpgradeSettingsMenu(client, iUpgradeIndex)
+void DisplayUpgradeSettingsMenu(int client, int iUpgradeIndex)
 {
-	new Handle:hMenu = CreateMenu(Menu_HandleUpgradeSettings, MENU_ACTIONS_DEFAULT);
-	SetMenuExitBackButton(hMenu, true);
+	Menu hMenu = new Menu(Menu_HandleUpgradeSettings);
+	hMenu.ExitBackButton = true;
 
-	new String:sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
+	char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
 	GetUpgradeTranslatedName(client, iUpgradeIndex, sTranslatedName, sizeof(sTranslatedName));
-	SetMenuTitle(hMenu, "%T\n-----\n%s\n", "Credits", client, GetClientCredits(client), sTranslatedName);
+	hMenu.SetTitle("%T\n-----\n%s\n", "Credits", client, GetClientCredits(client), sTranslatedName);
 	
-	new playerupgrade[PlayerUpgradeInfo];
+	int playerupgrade[PlayerUpgradeInfo];
 	GetPlayerUpgradeInfoByIndex(client, iUpgradeIndex, playerupgrade);
 	
-	decl String:sBuffer[64];
+	char sBuffer[64];
 	Format(sBuffer, sizeof(sBuffer), "%T: %T", "Enabled", client, playerupgrade[PUI_enabled]?"On":"Off", client);
-	AddMenuItem(hMenu, "enable", sBuffer);
+	hMenu.AddItem("enable", sBuffer);
 	
-	if(!GetConVarBool(g_hCVDisableLevelSelection))
+	if(!g_hCVDisableLevelSelection.BoolValue)
 	{
 		Format(sBuffer, sizeof(sBuffer), "%T: %d/%d", "Selected level", client, playerupgrade[PUI_selectedlevel], playerupgrade[PUI_purchasedlevel]);
-		AddMenuItem(hMenu, "", sBuffer, ITEMDRAW_DISABLED);
+		hMenu.AddItem("", sBuffer, ITEMDRAW_DISABLED);
 		Format(sBuffer, sizeof(sBuffer), "%T", "Increase selected level", client);
-		AddMenuItem(hMenu, "incselect", sBuffer, playerupgrade[PUI_selectedlevel]<playerupgrade[PUI_purchasedlevel]?ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
+		hMenu.AddItem("incselect", sBuffer, playerupgrade[PUI_selectedlevel]<playerupgrade[PUI_purchasedlevel]?ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
 		Format(sBuffer, sizeof(sBuffer), "%T", "Decrease selected level", client);
-		AddMenuItem(hMenu, "decselect", sBuffer, playerupgrade[PUI_selectedlevel]>0?ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
+		hMenu.AddItem("decselect", sBuffer, playerupgrade[PUI_selectedlevel]>0?ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
 	}
 	
-	new upgrade[InternalUpgradeInfo];
+	int upgrade[InternalUpgradeInfo];
 	GetUpgradeByIndex(iUpgradeIndex, upgrade);
 	
-	new bool:bHasVisuals = upgrade[UPGR_visualsConvar] != INVALID_HANDLE && upgrade[UPGR_enableVisuals];
-	new bool:bHasSounds = upgrade[UPGR_soundsConvar] != INVALID_HANDLE && upgrade[UPGR_enableSounds];
+	bool bHasVisuals = upgrade[UPGR_visualsConvar] != null && upgrade[UPGR_enableVisuals];
+	bool bHasSounds = upgrade[UPGR_soundsConvar] != null && upgrade[UPGR_enableSounds];
 	
 	if(bHasVisuals || bHasSounds)
 	{
-		AddMenuItem(hMenu, "", "", ITEMDRAW_SPACER);
+		hMenu.AddItem("", "", ITEMDRAW_SPACER);
 		if(bHasVisuals)
 		{
 			Format(sBuffer, sizeof(sBuffer), "%T: %T", "Visual effects", client, playerupgrade[PUI_visuals]?"On":"Off", client);
-			AddMenuItem(hMenu, "visuals", sBuffer);
+			hMenu.AddItem("visuals", sBuffer);
 		}
 		if(bHasSounds)
 		{
 			Format(sBuffer, sizeof(sBuffer), "%T: %T", "Sound effects", client, playerupgrade[PUI_sounds]?"On":"Off", client);
-			AddMenuItem(hMenu, "sounds", sBuffer);
+			hMenu.AddItem("sounds", sBuffer);
 		}
 	}
 	
 	g_iSelectedSettingsUpgrade[client] = iUpgradeIndex;
-	DisplayMenu(hMenu, client, MENU_TIME_FOREVER);
+	hMenu.Display(client, MENU_TIME_FOREVER);
 }
 
-public Menu_HandleUpgradeSettings(Handle:menu, MenuAction:action, param1, param2)
+public int Menu_HandleUpgradeSettings(Menu menu, MenuAction action, int param1, int param2)
 {
 	if(action == MenuAction_Select)
 	{
-		decl String:sInfo[16];
-		GetMenuItem(menu, param2, sInfo, sizeof(sInfo));
+		char sInfo[16];
+		menu.GetItem(param2, sInfo, sizeof(sInfo));
 		
-		new playerupgrade[PlayerUpgradeInfo];
+		int playerupgrade[PlayerUpgradeInfo];
 		GetPlayerUpgradeInfoByIndex(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade);
 		
 		if(StrEqual(sInfo, "enable"))
@@ -580,12 +580,12 @@ public Menu_HandleUpgradeSettings(Handle:menu, MenuAction:action, param1, param2
 		}
 		else if(StrEqual(sInfo, "incselect"))
 		{
-			if(!GetConVarBool(g_hCVDisableLevelSelection))
+			if(!g_hCVDisableLevelSelection.BoolValue)
 				SetClientSelectedUpgradeLevel(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade[PUI_selectedlevel]+1);
 		}
 		else if(StrEqual(sInfo, "decselect"))
 		{
-			if(playerupgrade[PUI_selectedlevel] > 0 && !GetConVarBool(g_hCVDisableLevelSelection))
+			if(playerupgrade[PUI_selectedlevel] > 0 && !g_hCVDisableLevelSelection.BoolValue)
 				SetClientSelectedUpgradeLevel(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade[PUI_selectedlevel]-1);
 		}
 		else if(StrEqual(sInfo, "visuals"))
@@ -605,27 +605,27 @@ public Menu_HandleUpgradeSettings(Handle:menu, MenuAction:action, param1, param2
 	{
 		g_iSelectedSettingsUpgrade[param1] = -1;
 		if(param2 == MenuCancel_ExitBack)
-			DisplayTopMenu(g_hRPGTopMenu, param1, TopMenuPosition_LastCategory);
+			g_hRPGTopMenu.Display(param1, TopMenuPosition_LastCategory);
 	}
 	else if(action == MenuAction_End)
 	{
-		CloseHandle(menu);
+		delete menu;
 	}
 }
 
-DisplayStatsMenu(client)
+void DisplayStatsMenu(int client)
 {
-	DisplayTopMenuCategory(g_hRPGTopMenu, g_TopMenuStats, client);
+	g_hRPGTopMenu.DisplayCategory(g_TopMenuStats, client);
 }
 
-public TopMenu_HandleStats(Handle:topmenu, TopMenuAction:action, TopMenuObject:object_id, param, String:buffer[], maxlength)
+public void TopMenu_HandleStats(TopMenu topmenu, TopMenuAction action, TopMenuObject object_id, int param, char[] buffer, int maxlength)
 {
 	switch(action)
 	{
 		case TopMenuAction_DisplayOption:
 		{
-			decl String:sName[64];
-			GetTopMenuObjName(topmenu, object_id, sName, sizeof(sName));
+			char sName[64];
+			topmenu.GetObjName(object_id, sName, sizeof(sName));
 			
 			if(StrEqual(sName, "level"))
 			{
@@ -650,8 +650,8 @@ public TopMenu_HandleStats(Handle:topmenu, TopMenuAction:action, TopMenuObject:o
 		}
 		case TopMenuAction_DrawOption:
 		{
-			decl String:sName[64];
-			GetTopMenuObjName(topmenu, object_id, sName, sizeof(sName));
+			char sName[64];
+			topmenu.GetObjName(object_id, sName, sizeof(sName));
 			
 			// HACKHACK: Don't disable the lastexp one
 			if(!StrEqual(sName, "lastexp"))
@@ -662,8 +662,8 @@ public TopMenu_HandleStats(Handle:topmenu, TopMenuAction:action, TopMenuObject:o
 		}
 		case TopMenuAction_SelectOption:
 		{
-			decl String:sName[64];
-			GetTopMenuObjName(topmenu, object_id, sName, sizeof(sName));
+			char sName[64];
+			topmenu.GetObjName(object_id, sName, sizeof(sName));
 			
 			if(StrEqual(sName, "lastexp"))
 			{
@@ -673,15 +673,15 @@ public TopMenu_HandleStats(Handle:topmenu, TopMenuAction:action, TopMenuObject:o
 	}	
 }
 
-DisplaySettingsMenu(client)
+void DisplaySettingsMenu(int client)
 {
-	DisplayTopMenuCategory(g_hRPGTopMenu, g_TopMenuSettings, client);
+	g_hRPGTopMenu.DisplayCategory(g_TopMenuSettings, client);
 }
 
-public TopMenu_HandleSettings(Handle:topmenu, TopMenuAction:action, TopMenuObject:object_id, param, String:buffer[], maxlength)
+public void TopMenu_HandleSettings(TopMenu topmenu, TopMenuAction action, TopMenuObject object_id, int param, char[] buffer, int maxlength)
 {
-	decl String:sName[64];
-	GetTopMenuObjName(topmenu, object_id, sName, sizeof(sName));
+	char sName[64];
+	topmenu.GetObjName(object_id, sName, sizeof(sName));
 	
 	switch(action)
 	{
@@ -705,7 +705,7 @@ public TopMenu_HandleSettings(Handle:topmenu, TopMenuAction:action, TopMenuObjec
 			if(StrEqual(sName, "resetstats"))
 			{
 				// Don't show the reset stats option, if disabled.
-				if(!GetConVarBool(g_hCVAllowSelfReset))
+				if(!g_hCVAllowSelfReset.BoolValue)
 					buffer[0] = ITEMDRAW_IGNORE;
 			}
 		}
@@ -713,38 +713,38 @@ public TopMenu_HandleSettings(Handle:topmenu, TopMenuAction:action, TopMenuObjec
 		{
 			if(StrEqual(sName, "resetstats"))
 			{
-				DisplayMenu(g_hConfirmResetStatsMenu, param, MENU_TIME_FOREVER);
+				g_hConfirmResetStatsMenu.Display(param, MENU_TIME_FOREVER);
 			}
 			else if(StrEqual(sName, "toggleautoshow"))
 			{
 				SetShowMenuOnLevelUp(param, !ShowMenuOnLevelUp(param));
-				DisplayTopMenu(g_hRPGTopMenu, param, TopMenuPosition_LastCategory);
+				g_hRPGTopMenu.Display(param, TopMenuPosition_LastCategory);
 			}
 			else if(StrEqual(sName, "togglefade"))
 			{
 				SetFadeScreenOnLevelUp(param, !FadeScreenOnLevelUp(param));
-				DisplayTopMenu(g_hRPGTopMenu, param, TopMenuPosition_LastCategory);
+				g_hRPGTopMenu.Display(param, TopMenuPosition_LastCategory);
 			}
 		}
 	}	
 }
 
-public Menu_ConfirmResetStats(Handle:menu, MenuAction:action, param1, param2)
+public int Menu_ConfirmResetStats(Menu menu, MenuAction action, int param1, int param2)
 {
 	if(action == MenuAction_Select)
 	{
-		decl String:sInfo[16];
-		GetMenuItem(menu, param2, sInfo, sizeof(sInfo));
+		char sInfo[16];
+		menu.GetItem(param2, sInfo, sizeof(sInfo));
 		
 		if(StrEqual(sInfo, "no"))
 		{
-			DisplayTopMenu(g_hRPGTopMenu, param1, TopMenuPosition_LastCategory);
+			g_hRPGTopMenu.Display(param1, TopMenuPosition_LastCategory);
 			return 0;
 		}
 		
 		// Are players allowed to reset themselves?
 		// Player might still had the menu open while this setting changed.
-		if(GetConVarBool(g_hCVAllowSelfReset))
+		if(g_hCVAllowSelfReset.BoolValue)
 		{
 			ResetStats(param1);
 			SetPlayerLastReset(param1, GetTime());
@@ -758,22 +758,22 @@ public Menu_ConfirmResetStats(Handle:menu, MenuAction:action, param1, param2)
 	else if(action == MenuAction_Display)
 	{
 		// Change the title
-		new Handle:hPanel = Handle:param2;
+		Panel hPanel = view_as<Panel>(param2);
 		
 		// Display the current credits in the title
-		decl String:sBuffer[256];
+		char sBuffer[256];
 		Format(sBuffer, sizeof(sBuffer), "%T\n-----\n%T\n", "Credits", param1, GetClientCredits(param1), "Confirm stats reset", param1);
 		
-		SetPanelTitle(hPanel, sBuffer);
+		hPanel.SetTitle(sBuffer);
 	}
 	else if(action == MenuAction_DisplayItem)
 	{
 		/* Get the display string, we'll use it as a translation phrase */
-		decl String:sDisplay[64];
-		GetMenuItem(menu, param2, "", 0, _, sDisplay, sizeof(sDisplay));
+		char sDisplay[64];
+		menu.GetItem(param2, "", 0, _, sDisplay, sizeof(sDisplay));
 
 		/* Translate the string to the client's language */
-		decl String:sBuffer[255];
+		char sBuffer[255];
 		Format(sBuffer, sizeof(sBuffer), "%T", sDisplay, param1);
 
 		/* Override the text */
@@ -782,26 +782,26 @@ public Menu_ConfirmResetStats(Handle:menu, MenuAction:action, param1, param2)
 	else if(action == MenuAction_Cancel)
 	{
 		if(param2 == MenuCancel_ExitBack)
-			DisplayTopMenu(g_hRPGTopMenu, param1, TopMenuPosition_LastCategory);
+			g_hRPGTopMenu.Display(param1, TopMenuPosition_LastCategory);
 	}
 	return 0;
 }
 
-DisplayHelpMenu(client)
+void DisplayHelpMenu(int client)
 {
-	DisplayTopMenuCategory(g_hRPGTopMenu, g_TopMenuHelp, client);
+	g_hRPGTopMenu.DisplayCategory(g_TopMenuHelp, client);
 }
 
-public TopMenu_HandleHelp(Handle:topmenu, TopMenuAction:action, TopMenuObject:object_id, param, String:buffer[], maxlength)
+public void TopMenu_HandleHelp(TopMenu topmenu, TopMenuAction action, TopMenuObject object_id, int param, char[] buffer, int maxlength)
 {
 	switch(action)
 	{
 		case TopMenuAction_DisplayOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			if(!GetUpgradeByShortname(sShortname[8], upgrade))
 				return;
 			
@@ -809,24 +809,24 @@ public TopMenu_HandleHelp(Handle:topmenu, TopMenuAction:action, TopMenuObject:ob
 				return;
 			
 			// Show the team this upgrade is locked to, if it is.
-			new String:sTeamlock[128];
-			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && GetConVarBool(g_hCVShowTeamlockNoticeOwnTeam)) && upgrade[UPGR_teamlock] < GetTeamCount())
+			char sTeamlock[128];
+			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade[UPGR_teamlock] < GetTeamCount())
 			{
 				GetTeamName(upgrade[UPGR_teamlock], sTeamlock, sizeof(sTeamlock));
 				Format(sTeamlock, sizeof(sTeamlock), " (%T)", "Is teamlocked", param, sTeamlock);
 			}
 			
-			new String:sDescription[MAX_UPGRADE_DESCRIPTION_LENGTH];
+			char sDescription[MAX_UPGRADE_DESCRIPTION_LENGTH];
 			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sDescription, sizeof(sDescription));
 			
 			Format(buffer, maxlength, "%s%s", sDescription, sTeamlock);
 		}
 		case TopMenuAction_DrawOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			// Don't show invalid upgrades at all in the menu.
 			if(!GetUpgradeByShortname(sShortname[8], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
 			{
@@ -834,7 +834,7 @@ public TopMenu_HandleHelp(Handle:topmenu, TopMenuAction:action, TopMenuObject:ob
 				return;
 			}
 			
-			new iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
 			
 			// Allow clients to read help about upgrades they no longer have access to, but don't show them, if they never bought it.
 			if(!HasAccessToUpgrade(param, upgrade) && iCurrentLevel <= 0)
@@ -853,40 +853,40 @@ public TopMenu_HandleHelp(Handle:topmenu, TopMenuAction:action, TopMenuObject:ob
 		}
 		case TopMenuAction_SelectOption:
 		{
-			decl String:sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
-			GetTopMenuObjName(topmenu, object_id, sShortname, sizeof(sShortname));
+			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
+			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			new upgrade[InternalUpgradeInfo];
+			int upgrade[InternalUpgradeInfo];
 			
 			// Bad upgrade?
 			if(!GetUpgradeByShortname(sShortname[8], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
 			{
-				DisplayTopMenu(g_hRPGTopMenu, param, TopMenuPosition_LastCategory);
+				g_hRPGTopMenu.Display(param, TopMenuPosition_LastCategory);
 				return;
 			}
 			
-			new String:sTranslatedName[MAX_UPGRADE_NAME_LENGTH], String:sTranslatedDescription[MAX_UPGRADE_DESCRIPTION_LENGTH];
+			char sTranslatedName[MAX_UPGRADE_NAME_LENGTH], sTranslatedDescription[MAX_UPGRADE_DESCRIPTION_LENGTH];
 			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
 			GetUpgradeTranslatedDescription(param, upgrade[UPGR_index], sTranslatedDescription, sizeof(sTranslatedDescription));
 			
 			Client_PrintToChat(param, false, "{OG}SM:RPG{N} > {G}%s{N}: %s", sTranslatedName, sTranslatedDescription);
 			
-			DisplayTopMenu(g_hRPGTopMenu, param, TopMenuPosition_LastCategory);
+			g_hRPGTopMenu.Display(param, TopMenuPosition_LastCategory);
 		}
 	}
 }
 
-DisplayOtherUpgradesMenu(client, targetClient)
+void DisplayOtherUpgradesMenu(int client, int targetClient)
 {
-	new Handle:hMenu = CreateMenu(Menu_HandleOtherUpgrades);
-	SetMenuExitButton(hMenu, true);
+	Menu hMenu = new Menu(Menu_HandleOtherUpgrades);
+	hMenu.ExitBackButton = true;
 	
-	SetMenuTitle(hMenu, "%N\n%T\n-----\n", targetClient, "Credits", client, GetClientCredits(targetClient));
+	hMenu.SetTitle("%N\n%T\n-----\n", targetClient, "Credits", client, GetClientCredits(targetClient));
 	
-	new iSize = GetUpgradeCount();
-	new upgrade[InternalUpgradeInfo], iCurrentLevel;
-	new String:sTranslatedName[MAX_UPGRADE_NAME_LENGTH], String:sLine[128], String:sIndex[8], String:sMaxlevel[8];
-	for(new i=0;i<iSize;i++)
+	int iSize = GetUpgradeCount();
+	int upgrade[InternalUpgradeInfo], iCurrentLevel;
+	char sTranslatedName[MAX_UPGRADE_NAME_LENGTH], sLine[128], sIndex[8], sMaxlevel[8];
+	for(int i=0;i<iSize;i++)
 	{
 		iCurrentLevel = GetClientPurchasedUpgradeLevel(targetClient, i);
 		GetUpgradeByIndex(i, upgrade);
@@ -896,7 +896,7 @@ DisplayOtherUpgradesMenu(client, targetClient)
 			continue;
 		
 		// Optionally show the maxlevel of the upgrade
-		if (GetConVarBool(g_hCVShowMaxLevelInMenu))
+		if (g_hCVShowMaxLevelInMenu.BoolValue)
 			Format(sMaxlevel, sizeof(sMaxlevel), "/%d", upgrade[UPGR_maxLevel]);
 		else
 			sMaxlevel[0] = '\0';
@@ -908,50 +908,50 @@ DisplayOtherUpgradesMenu(client, targetClient)
 			Format(sLine, sizeof(sLine), "%s Lvl %d MAX", sTranslatedName, iCurrentLevel);
 		else
 			Format(sLine, sizeof(sLine), "%s Lvl %d%s", sTranslatedName, iCurrentLevel, sMaxlevel);
-		AddMenuItem(hMenu, sIndex, sLine, ITEMDRAW_DISABLED);
+		hMenu.AddItem(sIndex, sLine, ITEMDRAW_DISABLED);
 	}
 	
-	DisplayMenu(hMenu, client, MENU_TIME_FOREVER);
+	hMenu.Display(client, MENU_TIME_FOREVER);
 }
 
-public Menu_HandleOtherUpgrades(Handle:menu, MenuAction:action, param1, param2)
+public int Menu_HandleOtherUpgrades(Menu menu, MenuAction action, int param1, int param2)
 {
 	if(action == MenuAction_End)
 	{
-		CloseHandle(menu);
+		delete menu;
 	}
 }
 
 // Helper functions to access those pubvars before they are declared..
-Handle:GetRPGTopMenu()
+TopMenu GetRPGTopMenu()
 {
 	return g_hRPGTopMenu;
 }
 
-TopMenuObject:GetUpgradesCategory()
+TopMenuObject GetUpgradesCategory()
 {
 	return g_TopMenuUpgrades;
 }
 
-TopMenuObject:GetSellCategory()
+TopMenuObject GetSellCategory()
 {
 	return g_TopMenuSell;
 }
 
-TopMenuObject:GetUpgradeSettingsCategory()
+TopMenuObject GetUpgradeSettingsCategory()
 {
 	return g_TopMenuUpgradeSettings;
 }
 
-TopMenuObject:GetHelpCategory()
+TopMenuObject GetHelpCategory()
 {
 	return g_TopMenuHelp;
 }
 
 // Handle the logic of the smrpg_show_upgrades_teamlock convar.
-GetItemDrawFlagsForTeamlock(iLevel, bool:bBuyMenu)
+int GetItemDrawFlagsForTeamlock(int iLevel, bool bBuyMenu)
 {
-	new iShowTeamlock = GetConVarInt(g_hCVShowUpgradesOfOtherTeam);
+	int iShowTeamlock = g_hCVShowUpgradesOfOtherTeam.IntValue;
 	switch(iShowTeamlock)
 	{
 		case SHOW_TEAMLOCK_NONE:
@@ -964,7 +964,7 @@ GetItemDrawFlagsForTeamlock(iLevel, bool:bBuyMenu)
 			if(iLevel > 0)
 			{
 				// Show it, but don't let him buy it.
-				if(bBuyMenu && !GetConVarBool(g_hCVBuyUpgradesOfOtherTeam))
+				if(bBuyMenu && !g_hCVBuyUpgradesOfOtherTeam.BoolValue)
 				{
 					return ITEMDRAW_DISABLED;
 				}
@@ -979,7 +979,7 @@ GetItemDrawFlagsForTeamlock(iLevel, bool:bBuyMenu)
 		case SHOW_TEAMLOCK_ALL:
 		{
 			// Show it, but don't let him buy it.
-			if(bBuyMenu && !GetConVarBool(g_hCVBuyUpgradesOfOtherTeam))
+			if(bBuyMenu && !g_hCVBuyUpgradesOfOtherTeam.BoolValue)
 			{
 				return ITEMDRAW_DISABLED;
 			}

--- a/scripting/smrpg/smrpg_players.sp
+++ b/scripting/smrpg/smrpg_players.sp
@@ -409,6 +409,24 @@ void SavePlayerUpgradeInfo(int client, int index, int playerupgrade[PlayerUpgrad
 	g_iPlayerInfo[client][PLR_upgrades].SetArray(index, playerupgrade[0], view_as<int>(PlayerUpgradeInfo));
 }
 
+// See if this player is a bot and we shouldn't process any info for him.
+bool IgnoreBotPlayer(int client)
+{
+	// Just checking for bots.
+	if(!IsFakeClient(client))
+		return false;
+	
+	// Bot features disabled as a whole.
+	if(!g_hCVBotEnable.BoolValue)
+		return true;
+	
+	// No human players on the server.
+	if(g_hCVBotNeedHuman.BoolValue && Client_GetCount(true, false) == 0)
+		return true;
+	
+	return false;
+}
+
 /**
  * Player upgrade info getter
  */

--- a/scripting/smrpg/smrpg_settings.sp
+++ b/scripting/smrpg/smrpg_settings.sp
@@ -1,52 +1,52 @@
 #pragma semicolon 1
 #include <sourcemod>
 
-new Handle:g_hSettings;
-new Handle:g_hfwdOnSettingsLoaded;
+StringMap g_hSettings;
+Handle g_hfwdOnSettingsLoaded;
 
-RegisterSettingsNatives()
+void RegisterSettingsNatives()
 {
 	CreateNative("SMRPG_GetSetting", Native_GetSetting);
 	CreateNative("SMRPG_SetSetting", Native_SetSetting);
 }
 
-RegisterSettingsForwards()
+void RegisterSettingsForwards()
 {
 	g_hfwdOnSettingsLoaded = CreateGlobalForward("SMRPG_OnSettingsLoaded", ET_Ignore);
 }
 
-InitSettings()
+void InitSettings()
 {
-	g_hSettings = CreateTrie();
+	g_hSettings = new StringMap();
 }
 
-LoadSettingsTable()
+void LoadSettingsTable()
 {
-	decl String:sQuery[64];
+	char sQuery[64];
 	Format(sQuery, sizeof(sQuery), "SELECT setting, value FROM %s", TBL_SETTINGS);
-	SQL_TQuery(g_hDatabase, SQL_ReadSettings, sQuery);
+	g_hDatabase.Query(SQL_ReadSettings, sQuery);
 }
 
-public SQL_ReadSettings(Handle:owner, Handle:hndl, const String:error[], any:data)
+public void SQL_ReadSettings(Database db, DBResultSet results, const char[] error, any data)
 {
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Error reading settings: %s", error);
 		return;
 	}
 	
 	// Remove any old settings.
-	ClearTrie(g_hSettings);
+	g_hSettings.Clear();
 	
-	decl String:sKey[64], String:sValue[256];
-	while(SQL_MoreRows(hndl))
+	char sKey[64], sValue[256];
+	while(results.MoreRows)
 	{
-		if(!SQL_FetchRow(hndl))
+		if(!results.FetchRow())
 			continue;
 		
-		SQL_FetchString(hndl, 0, sKey, sizeof(sKey));
-		SQL_FetchString(hndl, 1, sValue, sizeof(sValue));
-		SetTrieString(g_hSettings, sKey, sValue);
+		results.FetchString(0, sKey, sizeof(sKey));
+		results.FetchString(1, sValue, sizeof(sValue));
+		g_hSettings.SetString(sKey, sValue);
 	}
 	
 	// Make sure there is a last reset time in the database.
@@ -62,36 +62,38 @@ public SQL_ReadSettings(Handle:owner, Handle:hndl, const String:error[], any:dat
 	Call_Finish();
 }
 
-bool:GetSetting(const String:sKey[], String:sValue[], maxlen)
+bool GetSetting(const char[] sKey, char[] sValue, int maxlen)
 {
-	return GetTrieString(g_hSettings, sKey, sValue, maxlen);
+	return g_hSettings.GetString(sKey, sValue, maxlen);
 }
 
-SetSetting(const String:sKey[], String:sValue[])
+void SetSetting(const char[] sKey, char[] sValue)
 {
-	SetTrieString(g_hSettings, sKey, sValue);
-	decl String:sQuery[512], String:sKeyEscaped[strlen(sKey)*2+1], String:sValueEscaped[strlen(sValue)*2+1];
-	SQL_EscapeString(g_hDatabase, sKey, sKeyEscaped, strlen(sKey)*2+1);
-	SQL_EscapeString(g_hDatabase, sValue, sValueEscaped, strlen(sValue)*2+1);
+	g_hSettings.SetString(sKey, sValue);
+	char sQuery[512];
+	char[] sKeyEscaped = new char[strlen(sKey)*2+1];
+	char[] sValueEscaped = new char[strlen(sValue)*2+1];
+	g_hDatabase.Escape(sKey, sKeyEscaped, strlen(sKey)*2+1);
+	g_hDatabase.Escape(sValue, sValueEscaped, strlen(sValue)*2+1);
 	Format(sQuery, sizeof(sQuery), "REPLACE INTO %s (setting, value) VALUES (\"%s\", \"%s\");", TBL_SETTINGS, sKeyEscaped, sValueEscaped);
-	SQL_TQuery(g_hDatabase, SQL_DoNothing, sQuery);
+	g_hDatabase.Query(SQL_DoNothing, sQuery);
 }
 
-public Native_GetSetting(Handle:plugin, numParams)
+public int Native_GetSetting(Handle plugin, int numParams)
 {
-	decl String:sKey[64];
+	char sKey[64];
 	GetNativeString(1, sKey, sizeof(sKey));
-	new String:sBuffer[256];
+	char sBuffer[256];
 	if(!GetSetting(sKey, sBuffer, sizeof(sBuffer)))
-		return false;
-	new iLength = GetNativeCell(3);
+		return 0;
+	int iLength = GetNativeCell(3);
 	SetNativeString(2, sBuffer, iLength);
-	return true;
+	return 1;
 }
 
-public Native_SetSetting(Handle:plugin, numParams)
+public int Native_SetSetting(Handle plugin, int numParams)
 {
-	decl String:sKey[64], String:sValue[256];
+	char sKey[64], sValue[256];
 	GetNativeString(1, sKey, sizeof(sKey));
 	GetNativeString(2, sValue, sizeof(sValue));
 	SetSetting(sKey, sValue);

--- a/scripting/smrpg/smrpg_stats.sp
+++ b/scripting/smrpg/smrpg_stats.sp
@@ -217,7 +217,7 @@ bool Stats_AddExperience(int client, int &iExperience, const char[] sReason, boo
 	if(iExperience <= 0)
 		return false;
 	
-	IF_IGNORE_BOTS(client)
+	if(IgnoreBotPlayer(client))
 		return false;
 	
 	// Admin commands shouldn't worry about fairness.

--- a/scripting/smrpg/smrpg_stats.sp
+++ b/scripting/smrpg/smrpg_stats.sp
@@ -623,14 +623,13 @@ public int Native_GetTop10Players(Handle plugin, int numParams)
 	g_hDatabase.Query(SQL_GetTop10Native, sQuery, hData);
 }
 
-public void SQL_GetTop10Native(Database db, DBResultSet results, const char[] error, any data)
+public void SQL_GetTop10Native(Database db, DBResultSet results, const char[] error, DataPack data)
 {
-	DataPack dp = view_as<DataPack>(data);
-	dp.Reset();
-	Handle hPlugin = view_as<Handle>(dp.ReadCell());
-	Function callback = dp.ReadFunction();
-	int extraData = dp.ReadCell();
-	delete dp;
+	data.Reset();
+	Handle hPlugin = view_as<Handle>(data.ReadCell());
+	Function callback = data.ReadFunction();
+	int extraData = data.ReadCell();
+	delete data;
 	
 	// Don't care if the calling plugin is gone.
 	if(!IsValidPlugin(hPlugin))

--- a/scripting/smrpg/smrpg_stats.sp
+++ b/scripting/smrpg/smrpg_stats.sp
@@ -5,10 +5,10 @@
 // Allow to refetch the rank every 20 seconds.
 #define RANK_CACHE_UPDATE_INTERVAL 20
 
-new g_iCachedRank[MAXPLAYERS+1] = {-1,...};
-new g_iNextCacheUpdate[MAXPLAYERS+1];
-new g_iCachedRankCount = 0;
-new g_iNextCacheCountUpdate;
+int g_iCachedRank[MAXPLAYERS+1] = {-1,...};
+int g_iNextCacheUpdate[MAXPLAYERS+1];
+int g_iCachedRankCount = 0;
+int g_iNextCacheCountUpdate;
 
 enum SessionStats {
 	SS_JoinTime,
@@ -19,14 +19,14 @@ enum SessionStats {
 	bool:SS_WantsAutoUpdate,
 	bool:SS_WantsMenuOpen,
 	bool:SS_OKToClose,
-	Handle:SS_LastExperience
+	ArrayList:SS_LastExperience
 };
 
-new g_iPlayerSessionStartStats[MAXPLAYERS+1][SessionStats];
-new bool:g_bBackToStatsMenu[MAXPLAYERS+1];
+int g_iPlayerSessionStartStats[MAXPLAYERS+1][SessionStats];
+bool g_bBackToStatsMenu[MAXPLAYERS+1];
 
-new Handle:g_hfwdOnAddExperience;
-new Handle:g_hfwdOnAddExperiencePost;
+Handle g_hfwdOnAddExperience;
+Handle g_hfwdOnAddExperiencePost;
 
 // AFK Handling
 enum AFKInfo {
@@ -35,11 +35,11 @@ enum AFKInfo {
 	AFK_spawnTime,
 	AFK_deathTime
 }
-new g_PlayerAFKInfo[MAXPLAYERS+1][AFKInfo];
-new bool:g_bPlayerSpawnProtected[MAXPLAYERS+1];
+int g_PlayerAFKInfo[MAXPLAYERS+1][AFKInfo];
+bool g_bPlayerSpawnProtected[MAXPLAYERS+1];
 
 // Individual weapon experience settings
-new Handle:g_hWeaponExperience;
+StringMap g_hWeaponExperience;
 
 enum WeaponExperienceContainer {
 	Float:WXP_Damage,
@@ -47,56 +47,56 @@ enum WeaponExperienceContainer {
 	Float:WXP_Bonus
 };
 
-RegisterStatsNatives()
+void RegisterStatsNatives()
 {
-	// native bool:SMRPG_AddClientExperience(client, exp, const String:reason[], bool:bHideNotice, other=-1, SMRPG_ExpTranslationCb:callback=SMRPG_ExpTranslationCb:INVALID_FUNCTION);
+	// native bool SMRPG_AddClientExperience(int client, int exp, const char[] reason, bool bHideNotice, int other=-1, SMRPG_ExpTranslationCb callback=INVALID_FUNCTION);
 	CreateNative("SMRPG_AddClientExperience", Native_AddClientExperience);
-	// native SMRPG_LevelToExperience(iLevel);
+	// native int SMRPG_LevelToExperience(int iLevel);
 	CreateNative("SMRPG_LevelToExperience", Native_LevelToExperience);
-	// native SMRPG_GetClientRank(client);
+	// native int SMRPG_GetClientRank(int client);
 	CreateNative("SMRPG_GetClientRank", Native_GetClientRank);
-	// native SMRPG_GetRankCount();
+	// native int SMRPG_GetRankCount();
 	CreateNative("SMRPG_GetRankCount", Native_GetRankCount);
 	
-	// native SMRPG_GetTop10Players(SQLTCallback:callback, any:data=0);
+	// native void SMRPG_GetTop10Players(SQLQueryCallback callback, any data=0);
 	CreateNative("SMRPG_GetTop10Players", Native_GetTop10Players);
 	
-	// native bool:SMRPG_IsClientAFK(client);
+	// native bool SMRPG_IsClientAFK(int client);
 	CreateNative("SMRPG_IsClientAFK", Native_IsClientAFK);
-	// native bool:SMRPG_IsClientSpawnProtected(client);
+	// native bool SMRPG_IsClientSpawnProtected(int client);
 	CreateNative("SMRPG_IsClientSpawnProtected", Native_IsClientSpawnProtected);
 	
-	// native Float:SMRPG_GetWeaponExperience(const String:sWeapon[], WeaponExperienceType:type);
+	// native float SMRPG_GetWeaponExperience(const char[] sWeapon, WeaponExperienceType type);
 	CreateNative("SMRPG_GetWeaponExperience", Native_GetWeaponExperience);
 }
 
-RegisterStatsForwards()
+void RegisterStatsForwards()
 {
-	// forward Action:SMRPG_OnAddExperience(client, const String:reason[], &iExperience, other);
+	// forward Action SMRPG_OnAddExperience(int client, const char[] reason, int &iExperience, int other);
 	g_hfwdOnAddExperience = CreateGlobalForward("SMRPG_OnAddExperience", ET_Hook, Param_Cell, Param_String, Param_CellByRef, Param_Cell);
-	// forward SMRPG_OnAddExperiencePost(client, const String:reason[], iExperience, other);
+	// forward void SMRPG_OnAddExperiencePost(int client, const char[] reason, int iExperience, int other);
 	g_hfwdOnAddExperiencePost = CreateGlobalForward("SMRPG_OnAddExperiencePost", ET_Ignore, Param_Cell, Param_String, Param_Cell, Param_Cell);
 }
 
 /* Calculate the experience needed for this level */
-Stats_LvlToExp(iLevel)
+int Stats_LvlToExp(int iLevel)
 {
-	new iExp;
+	int iExp;
 	
 	if(iLevel <= 1)
-		iExp = GetConVarInt(g_hCVExpStart);
+		iExp = g_hCVExpStart.IntValue;
 	else
-		iExp = iLevel * GetConVarInt(g_hCVExpInc) + GetConVarInt(g_hCVExpStart);
+		iExp = iLevel * g_hCVExpInc.IntValue + g_hCVExpStart.IntValue;
 	
-	return iExp > GetConVarInt(g_hCVExpMax) ? GetConVarInt(g_hCVExpMax) : iExp;
+	return iExp > g_hCVExpMax.IntValue ? g_hCVExpMax.IntValue : iExp;
 }
 
 /* Calculate how many levels to increase by current level and experience */
-Stats_CalcLvlInc(iLevel, iExp)
+int Stats_CalcLvlInc(int iLevel, int iExp)
 {
-	new iLevelIncrease;
+	int iLevelIncrease;
 	
-	new iExpRequired = Stats_LvlToExp(iLevel);
+	int iExpRequired = Stats_LvlToExp(iLevel);
 	while(iExp >= iExpRequired)
 	{
 		iLevelIncrease++;
@@ -107,24 +107,25 @@ Stats_CalcLvlInc(iLevel, iExp)
 	return iLevelIncrease;
 }
 
-Stats_PlayerNewLevel(client, iLevelIncrease)
+void Stats_PlayerNewLevel(int client, int iLevelIncrease)
 {
-	new iMaxLevel, bool:bMaxLevelReset;
+	int iMaxLevel;
+	bool bMaxLevelReset;
 	if(IsFakeClient(client))
 	{
-		iMaxLevel = GetConVarInt(g_hCVBotMaxlevel);
-		bMaxLevelReset = GetConVarBool(g_hCVBotMaxlevelReset);
+		iMaxLevel = g_hCVBotMaxlevel.IntValue;
+		bMaxLevelReset = g_hCVBotMaxlevelReset.BoolValue;
 	}
 	else
 	{
-		iMaxLevel = GetConVarInt(g_hCVPlayerMaxlevel);
-		bMaxLevelReset = GetConVarBool(g_hCVPlayerMaxlevelReset);
+		iMaxLevel = g_hCVPlayerMaxlevel.IntValue;
+		bMaxLevelReset = g_hCVPlayerMaxlevelReset.BoolValue;
 	}
 	
 	// Check if the player reached the maxlevel
 	if(iMaxLevel > 0)
 	{
-		new iNewLevel = GetClientLevel(client) + iLevelIncrease;
+		int iNewLevel = GetClientLevel(client) + iLevelIncrease;
 		// Player surpassed the maxlevel?
 		if(iNewLevel > iMaxLevel)
 		{
@@ -150,8 +151,8 @@ Stats_PlayerNewLevel(client, iLevelIncrease)
 		return;
 	
 	// Make sure to keep the experience he gained in addition to the needed exp for the levels.
-	new iExperience = GetClientExperience(client);
-	for(new i=0;i<iLevelIncrease;i++)
+	int iExperience = GetClientExperience(client);
+	for(int i=0;i<iLevelIncrease;i++)
 	{
 		iExperience -= Stats_LvlToExp(GetClientLevel(client)+i);
 	}
@@ -163,7 +164,7 @@ Stats_PlayerNewLevel(client, iLevelIncrease)
 	SetClientExperience(client, iExperience);
 	
 	SetClientLevel(client, GetClientLevel(client)+iLevelIncrease);
-	SetClientCredits(client, GetClientCredits(client) + iLevelIncrease * GetConVarInt(g_hCVCreditsInc));
+	SetClientCredits(client, GetClientCredits(client) + iLevelIncrease * g_hCVCreditsInc.IntValue);
 	
 	DebugMsg("%N is now level %d (%d level increase(s))", client, GetClientLevel(client), iLevelIncrease);
 	
@@ -176,18 +177,18 @@ Stats_PlayerNewLevel(client, iLevelIncrease)
 	
 	if(FadeScreenOnLevelUp(client))
 	{
-		new String:sColor[16], String:sBuffers[4][4];
+		char sColor[16], sBuffers[4][4];
 		// Keep the default color if there is invalid input in the convar.
-		new iColor[] = {255, 215, 0, 40};
+		int iColor[] = {255, 215, 0, 40};
 		// Parse the "r g b a" convar string of the screen fading color.
-		GetConVarString(g_hCVFadeOnLevelColor, sColor, sizeof(sColor));
-		new iNum = ExplodeString(sColor, " ", sBuffers, 4, 4);
-		for(new i=0;i<iNum;i++)
+		g_hCVFadeOnLevelColor.GetString(sColor, sizeof(sColor));
+		int iNum = ExplodeString(sColor, " ", sBuffers, 4, 4);
+		for(int i=0;i<iNum;i++)
 			iColor[i] = StringToInt(sBuffers[i]);
 		Client_ScreenFade(client, 255, FFADE_OUT|FFADE_PURGE, 255, iColor[0], iColor[1], iColor[2], iColor[3]);
 	}
 	
-	if(GetConVarBool(g_hCVAnnounceNewLvl))
+	if(g_hCVAnnounceNewLvl.BoolValue)
 		Client_PrintToChatAll(false, "%t", "Client level changed", client, GetClientLevel(client));
 	
 	if(!IsFakeClient(client))
@@ -204,13 +205,13 @@ Stats_PlayerNewLevel(client, iLevelIncrease)
 			Client_PrintToChat(client, false, "%t", "You have new credits", GetClientCredits(client));
 		}
 	}
-	else if(GetConVarBool(g_hCVBotEnable))
+	else if(g_hCVBotEnable.BoolValue)
 	{
 		BotPickUpgrade(client);
 	}
 }
 
-bool:Stats_AddExperience(client, &iExperience, const String:sReason[], bool:bHideNotice, other, bool:bIgnoreChecks=false)
+bool Stats_AddExperience(int client, int &iExperience, const char[] sReason, bool bHideNotice, int other, bool bIgnoreChecks=false)
 {
 	// Nothing to add?
 	if(iExperience <= 0)
@@ -222,8 +223,8 @@ bool:Stats_AddExperience(client, &iExperience, const String:sReason[], bool:bHid
 	// Admin commands shouldn't worry about fairness.
 	if (!bIgnoreChecks)
 	{
-		new bool:bBotEnable = GetConVarBool(g_hCVBotEnable);
-		if(GetConVarBool(g_hCVNeedEnemies))
+		bool bBotEnable = g_hCVBotEnable.BoolValue;
+		if(g_hCVNeedEnemies.BoolValue)
 		{
 			// No enemies in the opposite team?
 			if(!Team_HaveAllPlayers(bBotEnable))
@@ -231,13 +232,14 @@ bool:Stats_AddExperience(client, &iExperience, const String:sReason[], bool:bHid
 		}
 		
 		// All players in the opposite team are AFK?
-		if(GetConVarBool(g_hCVEnemiesNotAFK))
+		if(g_hCVEnemiesNotAFK.BoolValue)
 		{
-			new iMyTeam = GetClientTeam(client);
+			int iMyTeam = GetClientTeam(client);
 			if(iMyTeam > 1)
 			{
-				new bool:bAllAFK, iTeam;
-				for(new i=1;i<=MaxClients;i++)
+				bool bAllAFK;
+				int iTeam;
+				for(int i=1;i<=MaxClients;i++)
 				{
 					if(IsClientInGame(i))
 					{
@@ -270,11 +272,11 @@ bool:Stats_AddExperience(client, &iExperience, const String:sReason[], bool:bHid
 	}
 	
 	// Don't give the players any more exp when they already reached the maxlevel.
-	new iMaxlevel;
+	int iMaxlevel;
 	if(IsFakeClient(client))
-		iMaxlevel = GetConVarInt(g_hCVBotMaxlevel);
+		iMaxlevel = g_hCVBotMaxlevel.IntValue;
 	else
-		iMaxlevel = GetConVarInt(g_hCVPlayerMaxlevel);
+		iMaxlevel = g_hCVPlayerMaxlevel.IntValue;
 	
 	if(iMaxlevel > 0 && GetClientLevel(client) >= iMaxlevel)
 		return false;
@@ -282,21 +284,21 @@ bool:Stats_AddExperience(client, &iExperience, const String:sReason[], bool:bHid
 	// Handle experience with bots
 	if(other > 0 && other <= MaxClients && IsClientInGame(other))
 	{
-		new bool:bClientBot = IsFakeClient(client);
-		new bool:bOtherBot = IsFakeClient(other);
+		bool bClientBot = IsFakeClient(client);
+		bool bOtherBot = IsFakeClient(other);
 		if(bClientBot && bOtherBot)
 		{
-			if(!GetConVarBool(g_hCVBotKillBot))
+			if(!g_hCVBotKillBot.BoolValue)
 				return false;
 		}
 		else if(bClientBot && !bOtherBot)
 		{
-			if(!GetConVarBool(g_hCVBotKillPlayer))
+			if(!g_hCVBotKillPlayer.BoolValue)
 				return false;
 		}
 		else if(!bClientBot && bOtherBot)
 		{
-			if(!GetConVarBool(g_hCVPlayerKillBot))
+			if(!g_hCVPlayerKillBot.BoolValue)
 				return false;
 		}
 	}
@@ -307,22 +309,22 @@ bool:Stats_AddExperience(client, &iExperience, const String:sReason[], bool:bHid
 	
 	SetClientExperience(client, GetClientExperience(client) + iExperience);
 	
-	new iExpRequired = Stats_LvlToExp(GetClientLevel(client));
+	int iExpRequired = Stats_LvlToExp(GetClientLevel(client));
 	
 	if(GetClientExperience(client) >= iExpRequired)
 		Stats_PlayerNewLevel(client, Stats_CalcLvlInc(GetClientLevel(client), GetClientExperience(client)));
 	
 	Stats_CallOnExperiencePostForward(client, sReason, iExperience, other);
 	
-	if(!bHideNotice && GetConVarBool(g_hCVExpNotice))
+	if(!bHideNotice && g_hCVExpNotice.BoolValue)
 		PrintHintText(client, "%t", "Experience Gained Hintbox", iExperience, GetClientExperience(client), Stats_LvlToExp(GetClientLevel(client)));
 	
 	return true;
 }
 
-Stats_PlayerDamage(attacker, victim, Float:fDamage, const String:sWeapon[])
+void Stats_PlayerDamage(int attacker, int victim, float fDamage, const char[] sWeapon)
 {
-	if(!GetConVarBool(g_hCVEnable))
+	if(!g_hCVEnable.BoolValue)
 		return;
 	
 	// Don't give the attacker any exp when his victim was afk.
@@ -334,17 +336,17 @@ Stats_PlayerDamage(attacker, victim, Float:fDamage, const String:sWeapon[])
 		return;
 	
 	// Ignore teamattack if not FFA
-	if(!GetConVarBool(g_hCVFFA) && GetClientTeam(attacker) == GetClientTeam(victim))
+	if(!g_hCVFFA.BoolValue && GetClientTeam(attacker) == GetClientTeam(victim))
 		return;
 	
-	new iExp = RoundToCeil(fDamage * GetWeaponExperience(sWeapon, WeaponExperience_Damage));
+	int iExp = RoundToCeil(fDamage * GetWeaponExperience(sWeapon, WeaponExperience_Damage));
 	
 	SMRPG_AddClientExperience(attacker, iExp, ExperienceReason_PlayerHurt, true, victim);
 }
 
-Stats_PlayerKill(attacker, victim, const String:sWeapon[])
+void Stats_PlayerKill(int attacker, int victim, const char[] sWeapon)
 {
-	if(!GetConVarBool(g_hCVEnable))
+	if(!g_hCVEnable.BoolValue)
 		return;
 	
 	// Don't give the attacker any exp when his victim was afk.
@@ -356,11 +358,11 @@ Stats_PlayerKill(attacker, victim, const String:sWeapon[])
 		return;
 	
 	// Ignore teamattack if not FFA
-	if(!GetConVarBool(g_hCVFFA) && GetClientTeam(attacker) == GetClientTeam(victim))
+	if(!g_hCVFFA.BoolValue && GetClientTeam(attacker) == GetClientTeam(victim))
 		return;
 	
-	new iExp = RoundToCeil(GetClientLevel(victim) * GetWeaponExperience(sWeapon, WeaponExperience_Kill) + GetWeaponExperience(sWeapon, WeaponExperience_Bonus));
-	new iExpMax = GetConVarInt(g_hCVExpKillMax);
+	int iExp = RoundToCeil(GetClientLevel(victim) * GetWeaponExperience(sWeapon, WeaponExperience_Kill) + GetWeaponExperience(sWeapon, WeaponExperience_Bonus));
+	int iExpMax = g_hCVExpKillMax.IntValue;
 	// Limit the possible experience to this.
 	if(iExpMax > 0 && iExp > iExpMax)
 		iExp = iExpMax;
@@ -368,12 +370,12 @@ Stats_PlayerKill(attacker, victim, const String:sWeapon[])
 	SMRPG_AddClientExperience(attacker, iExp, ExperienceReason_PlayerKill, false, victim);
 }
 
-Stats_WinningTeam(iTeam)
+void Stats_WinningTeam(int iTeam)
 {
-	if(!GetConVarBool(g_hCVEnable))
+	if(!g_hCVEnable.BoolValue)
 		return;
 	
-	new Float:fTeamRatio;
+	float fTeamRatio;
 	if(iTeam == 2)
 		fTeamRatio = SMRPG_TeamRatio(3);
 	else if(iTeam == 3)
@@ -381,21 +383,21 @@ Stats_WinningTeam(iTeam)
 	else
 		return;
 	
-	new iExperience;
-	for(new i=1;i<=MaxClients;i++)
+	int iExperience;
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i) && GetClientTeam(i) == iTeam)
 		{
-			iExperience = RoundToCeil(float(Stats_LvlToExp(GetClientLevel(i))) * GetConVarFloat(g_hCVExpTeamwin) * fTeamRatio);
+			iExperience = RoundToCeil(float(Stats_LvlToExp(GetClientLevel(i))) * g_hCVExpTeamwin.FloatValue * fTeamRatio);
 			SMRPG_AddClientExperience(i, iExperience, ExperienceReason_RoundEnd, false, -1);
 		}
 	}
 }
 
-// forward Action:SMRPG_OnAddExperience(client, const String:reason[], &iExperience, other);
-Action:Stats_CallOnExperienceForward(client, const String:sReason[], &iExperience, other)
+// forward Action SMRPG_OnAddExperience(int client, const char[] reason, int &iExperience, int other);
+Action Stats_CallOnExperienceForward(int client, const char[] sReason, int &iExperience, int other)
 {
-	new Action:result;
+	Action result;
 	Call_StartForward(g_hfwdOnAddExperience);
 	Call_PushCell(client);
 	Call_PushString(sReason);
@@ -405,8 +407,8 @@ Action:Stats_CallOnExperienceForward(client, const String:sReason[], &iExperienc
 	return result;
 }
 
-// forward SMRPG_OnAddExperiencePost(client, const String:reason[], iExperience, other);
-Stats_CallOnExperiencePostForward(client, const String:sReason[], iExperience, other)
+// forward void SMRPG_OnAddExperiencePost(int client, const char[] reason, int iExperience, int other);
+void Stats_CallOnExperiencePostForward(int client, const char[] sReason, int iExperience, int other)
 {
 	Call_StartForward(g_hfwdOnAddExperiencePost);
 	Call_PushCell(client);
@@ -417,15 +419,15 @@ Stats_CallOnExperiencePostForward(client, const String:sReason[], iExperience, o
 }
 
 // AFK Handling
-StartAFKChecker()
+void StartAFKChecker()
 {
 	CreateTimer(0.5, Timer_CheckAFKPlayers, _, TIMER_FLAG_NO_MAPCHANGE|TIMER_REPEAT);
 }
 
-public Action:Timer_CheckAFKPlayers(Handle:timer)
+public Action Timer_CheckAFKPlayers(Handle timer)
 {
-	new Float:fOrigin[3], Float:fLastPosition[3];
-	for(new i=1;i<=MaxClients;i++)
+	float fOrigin[3], fLastPosition[3];
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i) && IsPlayerAlive(i) && GetClientTeam(i) > 1)
 		{
@@ -434,7 +436,7 @@ public Action:Timer_CheckAFKPlayers(Handle:timer)
 			// See if the player just spawned..
 			if(g_PlayerAFKInfo[i][AFK_spawnTime] > 0)
 			{
-				new iDifference = GetTime() - g_PlayerAFKInfo[i][AFK_spawnTime];
+				int iDifference = GetTime() - g_PlayerAFKInfo[i][AFK_spawnTime];
 				// The player spawned 2 seconds ago. He's now ready to be checked for being afk again.
 				if(iDifference > 2)
 				{
@@ -472,12 +474,12 @@ public Action:Timer_CheckAFKPlayers(Handle:timer)
 	return Plugin_Continue;
 }
 
-bool:IsClientAFK(client)
+bool IsClientAFK(int client)
 {
 	if(g_PlayerAFKInfo[client][AFK_startTime] == 0)
 		return false;
 	
-	new iAFKTime = GetConVarInt(g_hCVAFKTime);
+	int iAFKTime = g_hCVAFKTime.IntValue;
 	if(iAFKTime <= 0)
 		return false;
 	
@@ -486,23 +488,23 @@ bool:IsClientAFK(client)
 	return false;
 }
 
-ResetAFKPlayer(client)
+void ResetAFKPlayer(int client)
 {
 	g_PlayerAFKInfo[client][AFK_startTime] = 0;
 	g_PlayerAFKInfo[client][AFK_spawnTime] = 0;
 	g_PlayerAFKInfo[client][AFK_deathTime] = 0;
-	Array_Copy(g_PlayerAFKInfo[client][AFK_lastPosition], Float:{0.0,0.0,0.0}, 3);
+	Array_Copy(g_PlayerAFKInfo[client][AFK_lastPosition], view_as<float>({0.0,0.0,0.0}), 3);
 }
 
 // Spawn Protection handling
-bool:IsClientSpawnProtected(client)
+bool IsClientSpawnProtected(int client)
 {
-	if(!GetConVarBool(g_hCVSpawnProtect))
+	if(!g_hCVSpawnProtect.BoolValue)
 		return false;
 	return g_bPlayerSpawnProtected[client];
 }
 
-ResetSpawnProtection(client)
+void ResetSpawnProtection(int client)
 {
 	g_bPlayerSpawnProtected[client] = false;
 }
@@ -510,43 +512,39 @@ ResetSpawnProtection(client)
 /**
  * Native Callbacks
  */
-// native bool:SMRPG_AddClientExperience(client, &exp, const String:reason[], bool:bHideNotice, other=-1, SMRPG_ExpTranslationCb:callback=SMRPG_ExpTranslationCb:INVALID_FUNCTION);
-public Native_AddClientExperience(Handle:plugin, numParams)
+// native bool SMRPG_AddClientExperience(int client, int &exp, const char[] reason, bool bHideNotice, int other=-1, SMRPG_ExpTranslationCb callback=INVALID_FUNCTION);
+public int Native_AddClientExperience(Handle plugin, int numParams)
 {
-	new client = GetNativeCell(1);
+	int client = GetNativeCell(1);
 	if(client < 0 || client > MaxClients)
 	{
 		ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d.", client);
 		return false;
 	}
 	
-	new iExperience = GetNativeCellRef(2);
-	new iLen;
+	int iExperience = GetNativeCellRef(2);
+	int iLen;
 	GetNativeStringLength(3, iLen);
-	new String:sReason[iLen+1];
+	char[] sReason = new char[iLen+1];
 	GetNativeString(3, sReason, iLen+1);
 	
-	new bool:bHideNotice = bool:GetNativeCell(4);
-	new other = GetNativeCell(5);
-#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
-	new Function:translationCallback = GetNativeFunction(6);
-#else
-	new Function:translationCallback = Function:GetNativeCell(6);
-#endif
+	bool bHideNotice = view_as<bool>(GetNativeCell(4));
+	int other = GetNativeCell(5);
+	Function translationCallback = GetNativeFunction(6);
 	
-	new iOriginalExperience = iExperience;
+	int iOriginalExperience = iExperience;
 	// TODO: Expose bIgnoreChecks parameter.
-	new bool:bAdded = Stats_AddExperience(client, iExperience, sReason, bHideNotice, other);
+	bool bAdded = Stats_AddExperience(client, iExperience, sReason, bHideNotice, other);
 	if(iOriginalExperience != iExperience)
 		SetNativeCellRef(2, iExperience);
 	
 	if(bAdded && !IsFakeClient(client))
 	{
-		new String:sTranslatedReason[256];
+		char sTranslatedReason[256];
 		strcopy(sTranslatedReason, sizeof(sTranslatedReason), sReason);
 		if(translationCallback != INVALID_FUNCTION)
 		{
-			// functag SMRPG_ExpTranslationCb(client, const String:reason[], iExperience, other, String:buffer[], maxlen);
+			// functag SMRPG_ExpTranslationCb(client, const char[] reason, iExperience, other, char[] buffer, maxlen);
 			Call_StartFunction(plugin, translationCallback);
 			Call_PushCell(client);
 			Call_PushString(sReason);
@@ -572,87 +570,67 @@ public Native_AddClientExperience(Handle:plugin, numParams)
 	return bAdded;
 }
 
-public Native_LevelToExperience(Handle:plugin, numParams)
+public int Native_LevelToExperience(Handle plugin, int numParams)
 {
-	new iLevel = GetNativeCell(1);
+	int iLevel = GetNativeCell(1);
 	return Stats_LvlToExp(iLevel);
 }
 
-public Native_GetClientRank(Handle:plugin, numParams)
+public int Native_GetClientRank(Handle plugin, int numParams)
 {
-	new client = GetNativeCell(1);
+	int client = GetNativeCell(1);
 	if(client < 0 || client > MaxClients)
-	{
-		ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d.", client);
-		return false;
-	}
+		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d.", client);
 	
 	return GetClientRank(client);
 }
 
-public Native_GetRankCount(Handle:plugin, numParams)
+public int Native_GetRankCount(Handle plugin, int numParams)
 {
 	return GetRankCount();
 }
 
-public Native_IsClientAFK(Handle:plugin, numParams)
+public int Native_IsClientAFK(Handle plugin, int numParams)
 {
-	new client = GetNativeCell(1);
+	int client = GetNativeCell(1);
 	if(client < 0 || client > MaxClients)
-	{
-		ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d.", client);
-		return false;
-	}
+		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d.", client);
 	
 	return IsClientAFK(client);
 }
 
-public Native_IsClientSpawnProtected(Handle:plugin, numParams)
+public int Native_IsClientSpawnProtected(Handle plugin, int numParams)
 {
-	new client = GetNativeCell(1);
+	int client = GetNativeCell(1);
 	if(client < 0 || client > MaxClients)
-	{
-		ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d.", client);
-		return false;
-	}
+		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid client index %d.", client);
 	
 	return IsClientSpawnProtected(client);
 }
 
-public Native_GetTop10Players(Handle:plugin, numParams)
+public int Native_GetTop10Players(Handle plugin, int numParams)
 {
-#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
-	new Function:callback = GetNativeFunction(1);
-#else
-	new Function:callback = Function:GetNativeCell(1);
-#endif
-	new data = GetNativeCell(2);
+	Function callback = GetNativeFunction(1);
+	int data = GetNativeCell(2);
 	
-	new Handle:hData = CreateDataPack();
-	WritePackCell(hData, _:plugin);
-#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
-	WritePackFunction(hData, callback);
-#else
-	WritePackCell(hData, _:callback);
-#endif
-	WritePackCell(hData, data);
+	DataPack hData = new DataPack();
+	hData.WriteCell(view_as<int>(plugin));
+	hData.WriteFunction(callback);
+	hData.WriteCell(data);
 	
-	decl String:sQuery[128];
+	char sQuery[128];
 	Format(sQuery, sizeof(sQuery), "SELECT name, level, experience, credits FROM %s ORDER BY level DESC, experience DESC LIMIT 10", TBL_PLAYERS);
-	SQL_TQuery(g_hDatabase, SQL_GetTop10Native, sQuery, hData);
+	g_hDatabase.Query(SQL_GetTop10Native, sQuery, hData);
 }
 
-public SQL_GetTop10Native(Handle:owner, Handle:hndl, const String:error[], any:data)
+public void SQL_GetTop10Native(Database db, DBResultSet results, const char[] error, any data)
 {
-	ResetPack(data);
-	new Handle:hPlugin = Handle:ReadPackCell(data);
-#if SOURCEMOD_V_MAJOR >= 1 && SOURCEMOD_V_MINOR >= 7
-	new Function:callback = ReadPackFunction(data);
-#else
-	new Function:callback = Function:ReadPackCell(data);
-#endif
-	new extraData = ReadPackCell(data);
-	CloseHandle(data);
+	DataPack dp = view_as<DataPack>(data);
+	dp.Reset();
+	Handle hPlugin = view_as<Handle>(dp.ReadCell());
+	Function callback = dp.ReadFunction();
+	int extraData = dp.ReadCell();
+	delete dp;
 	
 	// Don't care if the calling plugin is gone.
 	if(!IsValidPlugin(hPlugin))
@@ -660,24 +638,24 @@ public SQL_GetTop10Native(Handle:owner, Handle:hndl, const String:error[], any:d
 	
 	Call_StartFunction(hPlugin, callback);
 	Call_PushCell(INVALID_HANDLE);
-	Call_PushCell(hndl);
+	Call_PushCell(results);
 	Call_PushString(error);
 	Call_PushCell(extraData);
 	Call_Finish();
 }
 
-// native Float:SMRPG_GetWeaponExperience(const String:sWeapon[], WeaponExperienceType:type);
-public Native_GetWeaponExperience(Handle:plugin, numParams)
+// native float SMRPG_GetWeaponExperience(const char[] sWeapon, WeaponExperienceType type);
+public int Native_GetWeaponExperience(Handle plugin, int numParams)
 {
-	new String:sWeapon[64], WeaponExperienceType:type;
+	char sWeapon[64];
 	GetNativeString(1, sWeapon, sizeof(sWeapon));
-	type = WeaponExperienceType:GetNativeCell(2);
+	WeaponExperienceType type = view_as<WeaponExperienceType>(GetNativeCell(2));
 	
-	return _:GetWeaponExperience(sWeapon, type);
+	return view_as<int>(GetWeaponExperience(sWeapon, type));
 }
 
 // rpgsession handling
-InitPlayerSessionStartStats(client)
+void InitPlayerSessionStartStats(int client)
 {
 	g_iPlayerSessionStartStats[client][SS_JoinTime] = GetTime();
 	g_iPlayerSessionStartStats[client][SS_JoinLevel] = GetClientLevel(client);
@@ -688,13 +666,13 @@ InitPlayerSessionStartStats(client)
 	g_iPlayerSessionStartStats[client][SS_WantsMenuOpen] = false;
 	g_iPlayerSessionStartStats[client][SS_OKToClose] = false;
 	
-	new Handle:hLastExperience = CreateArray(ByteCountToCells(256));
-	ResizeArray(hLastExperience, GetConVarInt(g_hCVLastExperienceCount));
-	SetArrayString(hLastExperience, 0, "");
+	ArrayList hLastExperience = new ArrayList(ByteCountToCells(256));
+	hLastExperience.Resize(g_hCVLastExperienceCount.IntValue);
+	hLastExperience.SetString(0, "");
 	g_iPlayerSessionStartStats[client][SS_LastExperience] = hLastExperience;
 }
 
-ResetPlayerSessionStats(client)
+void ResetPlayerSessionStats(int client)
 {
 	g_iPlayerSessionStartStats[client][SS_JoinTime] = 0;
 	g_iPlayerSessionStartStats[client][SS_JoinLevel] = 0;
@@ -708,43 +686,43 @@ ResetPlayerSessionStats(client)
 }
 
 // Use our own forward to initialize the session info :)
-public SMRPG_OnClientLoaded(client)
+public void SMRPG_OnClientLoaded(int client)
 {
 	// Only set it once and leave it that way until he really disconnects.
 	if(g_iPlayerSessionStartStats[client][SS_JoinTime] == 0)
 		InitPlayerSessionStartStats(client);
 }
 
-InsertSessionExperienceString(client, const String:sExperience[])
+void InsertSessionExperienceString(int client, const char[] sExperience)
 {
-	new Handle:hLastExperience = g_iPlayerSessionStartStats[client][SS_LastExperience];
+	ArrayList hLastExperience = g_iPlayerSessionStartStats[client][SS_LastExperience];
 	// Not loaded yet..
-	if(hLastExperience == INVALID_HANDLE)
+	if(hLastExperience == null)
 		return;
 	
 	// Insert the string at the start of the array!
-	ShiftArrayUp(hLastExperience, 0);
-	SetArrayString(hLastExperience, 0, sExperience);
+	hLastExperience.ShiftUp(0);
+	hLastExperience.SetString(0, sExperience);
 }
 
-public ConVar_LastExperienceCountChanged(Handle:convar, const String:oldValue[], const String:newValue[])
+public void ConVar_LastExperienceCountChanged(ConVar convar, const char[] oldValue, const char[] newValue)
 {
 	// Apply the new size immediately.
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(g_iPlayerSessionStartStats[i][SS_JoinTime] > 0)
-			ResizeArray(g_iPlayerSessionStartStats[i][SS_LastExperience], GetConVarInt(convar));
+			g_iPlayerSessionStartStats[i][SS_LastExperience].Resize(convar.IntValue);
 	}
 }
 
-StartSessionMenuUpdater()
+void StartSessionMenuUpdater()
 {
 	CreateTimer(1.0, Timer_UpdateSessionMenus, _, TIMER_FLAG_NO_MAPCHANGE|TIMER_REPEAT);
 }
 
-public Action:Timer_UpdateSessionMenus(Handle:timer)
+public Action Timer_UpdateSessionMenus(Handle timer)
 {
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		// Refresh the contents of the menu here.
 		if(IsClientInGame(i) && !IsFakeClient(i) && g_iPlayerSessionStartStats[i][SS_WantsMenuOpen] && g_iPlayerSessionStartStats[i][SS_WantsAutoUpdate])
@@ -754,62 +732,62 @@ public Action:Timer_UpdateSessionMenus(Handle:timer)
 	return Plugin_Continue;
 }
 
-DisplaySessionStatsMenu(client)
+void DisplaySessionStatsMenu(int client)
 {
-	new Handle:hPanel = CreatePanel();
+	Panel hPanel = new Panel();
 	
-	decl String:sBuffer[128];
+	char sBuffer[128];
 	Format(sBuffer, sizeof(sBuffer), "%T", "Stats", client);
-	DrawPanelItem(hPanel, sBuffer);
+	hPanel.DrawItem(sBuffer);
 	
 	Format(sBuffer, sizeof(sBuffer), "  %T", "Level", client, GetClientLevel(client));
-	DrawPanelText(hPanel, sBuffer);
+	hPanel.DrawText(sBuffer);
 	Format(sBuffer, sizeof(sBuffer), "  %T", "Experience short", client, GetClientExperience(client), Stats_LvlToExp(GetClientLevel(client)));
-	DrawPanelText(hPanel, sBuffer);
+	hPanel.DrawText(sBuffer);
 	Format(sBuffer, sizeof(sBuffer), "  %T", "Credits", client, GetClientCredits(client));
-	DrawPanelText(hPanel, sBuffer);
+	hPanel.DrawText(sBuffer);
 	Format(sBuffer, sizeof(sBuffer), "  %T", "Rank", client, GetClientRank(client), GetRankCount());
-	DrawPanelText(hPanel, sBuffer);
+	hPanel.DrawText(sBuffer);
 	
 	Format(sBuffer, sizeof(sBuffer), "%T", "Session", client);
-	DrawPanelItem(hPanel, sBuffer);
+	hPanel.DrawItem(sBuffer);
 	
 	SecondsToString(sBuffer, sizeof(sBuffer), GetTime()-g_iPlayerSessionStartStats[client][SS_JoinTime], false);
 	Format(sBuffer, sizeof(sBuffer), "  %T", "Playtime", client, sBuffer);
-	DrawPanelText(hPanel, sBuffer);
+	hPanel.DrawText(sBuffer);
 	
-	new iChangedLevels = GetClientLevel(client) - g_iPlayerSessionStartStats[client][SS_JoinLevel];
+	int iChangedLevels = GetClientLevel(client) - g_iPlayerSessionStartStats[client][SS_JoinLevel];
 	Format(sBuffer, sizeof(sBuffer), "  %T: %s%d", "Changed level", client, iChangedLevels>0?"+":"", iChangedLevels);
-	DrawPanelText(hPanel, sBuffer);
+	hPanel.DrawText(sBuffer);
 	
 	// Need to calculate the total earned experience.
-	new iEarnedExperience = GetClientExperience(client) - g_iPlayerSessionStartStats[client][SS_JoinExperience];
-	for(new i=0;i<iChangedLevels;i++)
+	int iEarnedExperience = GetClientExperience(client) - g_iPlayerSessionStartStats[client][SS_JoinExperience];
+	for(int i=0;i<iChangedLevels;i++)
 	{
 		iEarnedExperience += Stats_LvlToExp(g_iPlayerSessionStartStats[client][SS_JoinLevel]+i);
 	}
 	
 	Format(sBuffer, sizeof(sBuffer), "  %T: %s%d", "Changed experience", client, iEarnedExperience>0?"+":"", iEarnedExperience);
-	DrawPanelText(hPanel, sBuffer);
+	hPanel.DrawText(sBuffer);
 	
-	new iBuffer = GetClientCredits(client) - g_iPlayerSessionStartStats[client][SS_JoinCredits];
+	int iBuffer = GetClientCredits(client) - g_iPlayerSessionStartStats[client][SS_JoinCredits];
 	Format(sBuffer, sizeof(sBuffer), "  %T: %s%d", "Changed credits", client, iBuffer>0?"+":"", iBuffer);
-	DrawPanelText(hPanel, sBuffer);
+	hPanel.DrawText(sBuffer);
 	
 	if(g_iPlayerSessionStartStats[client][SS_JoinRank] != -1)
 	{
 		iBuffer = g_iPlayerSessionStartStats[client][SS_JoinRank] - GetClientRank(client);
 		Format(sBuffer, sizeof(sBuffer), "  %T: %s%d", "Changed rank", client, iBuffer>0?"+":"", iBuffer);
-		DrawPanelText(hPanel, sBuffer);
+		hPanel.DrawText(sBuffer);
 	}
 	
-	DrawPanelItem(hPanel, "", ITEMDRAW_SPACER);
+	hPanel.DrawItem("", ITEMDRAW_SPACER);
 	
 	Format(sBuffer, sizeof(sBuffer), "%T: %T", "Auto refresh panel", client, (g_iPlayerSessionStartStats[client][SS_WantsAutoUpdate]?"Yes":"No"), client);
-	DrawPanelItem(hPanel, sBuffer);
+	hPanel.DrawItem(sBuffer);
 	
 	Format(sBuffer, sizeof(sBuffer), "%T", "Last Experience", client);
-	DrawPanelItem(hPanel, sBuffer);
+	hPanel.DrawItem(sBuffer);
 	
 	// The old menu is closed when we open the new one.
 	// The logic here is like this:
@@ -821,11 +799,11 @@ DisplaySessionStatsMenu(client)
 		g_iPlayerSessionStartStats[client][SS_OKToClose] = true;
 	g_iPlayerSessionStartStats[client][SS_WantsMenuOpen] = true;
 	
-	SendPanelToClient(hPanel, client, Panel_HandleSessionMenu, MENU_TIME_FOREVER);
-	CloseHandle(hPanel);
+	hPanel.Send(client, Panel_HandleSessionMenu, MENU_TIME_FOREVER);
+	delete hPanel;
 }
 
-public Panel_HandleSessionMenu(Handle:menu, MenuAction:action, param1, param2)
+public int Panel_HandleSessionMenu(Menu menu, MenuAction action, int param1, int param2)
 {
 	if(action == MenuAction_Select)
 	{
@@ -853,44 +831,44 @@ public Panel_HandleSessionMenu(Handle:menu, MenuAction:action, param1, param2)
 	}
 }
 
-DisplaySessionLastExperienceMenu(client, bool:bBackToStatsMenu)
+void DisplaySessionLastExperienceMenu(int client, bool bBackToStatsMenu)
 {
-	new Handle:hLastExperience = g_iPlayerSessionStartStats[client][SS_LastExperience];
+	ArrayList hLastExperience = g_iPlayerSessionStartStats[client][SS_LastExperience];
 	// Player not loaded yet.
-	if(hLastExperience == INVALID_HANDLE)
+	if(hLastExperience == null)
 		return;
 
 	// Remember what the back button in the menu should do.
 	g_bBackToStatsMenu[client] = bBackToStatsMenu;
 	
-	new Handle:hMenu = CreateMenu(Menu_HandleLastExperience);
-	SetMenuTitle(hMenu, "%t: %N", "Last Experience", client);
-	SetMenuExitBackButton(hMenu, true);
+	Menu hMenu = new Menu(Menu_HandleLastExperience);
+	hMenu.SetTitle("%t: %N", "Last Experience", client);
+	hMenu.ExitBackButton = true;
 	
-	new iSize = GetArraySize(hLastExperience);
-	decl String:sBuffer[256];
-	for(new i=0;i<iSize;i++)
+	int iSize = hLastExperience.Length;
+	char sBuffer[256];
+	for(int i=0;i<iSize;i++)
 	{
-		if(GetArrayString(hLastExperience, i, sBuffer, sizeof(sBuffer)) <= 0)
+		if(hLastExperience.GetString(i, sBuffer, sizeof(sBuffer)) <= 0)
 			break;
 		
-		AddMenuItem(hMenu, "", sBuffer, ITEMDRAW_DISABLED);
+		hMenu.AddItem("", sBuffer, ITEMDRAW_DISABLED);
 	}
 	
 	if(GetMenuItemCount(hMenu) == 0)
 	{
 		Format(sBuffer, sizeof(sBuffer), "%T", "Nothing to display", client);
-		AddMenuItem(hMenu, "", sBuffer, ITEMDRAW_DISABLED);
+		hMenu.AddItem("", sBuffer, ITEMDRAW_DISABLED);
 	}
 	
-	DisplayMenu(hMenu, client, MENU_TIME_FOREVER);
+	hMenu.Display(client, MENU_TIME_FOREVER);
 }
 
-public Menu_HandleLastExperience(Handle:menu, MenuAction:action, param1, param2)
+public int Menu_HandleLastExperience(Menu menu, MenuAction action, int param1, int param2)
 {
 	if(action == MenuAction_End)
 	{
-		CloseHandle(menu);
+		delete menu;
 	}
 	else if(action == MenuAction_Cancel && param2 == MenuCancel_ExitBack)
 	{
@@ -905,18 +883,18 @@ public Menu_HandleLastExperience(Handle:menu, MenuAction:action, param1, param2)
 	CRPG_RankManager
 	////////////////////////////////////// */
 
-UpdateClientRank(client)
+void UpdateClientRank(int client)
 {
 	if(!g_hDatabase)
 		return;
 	
-	decl String:sQuery[128];
+	char sQuery[128];
 	Format(sQuery, sizeof(sQuery), "SELECT COUNT(*) FROM %s WHERE level > %d OR (level = %d AND experience > %d)", TBL_PLAYERS, GetClientLevel(client), GetClientLevel(client), GetClientExperience(client));
-	SQL_TQuery(g_hDatabase, SQL_GetClientRank, sQuery, GetClientUserId(client));
+	g_hDatabase.Query(SQL_GetClientRank, sQuery, GetClientUserId(client));
 	g_iNextCacheUpdate[client] = GetTime() + RANK_CACHE_UPDATE_INTERVAL;
 }
 
-GetClientRank(client)
+int GetClientRank(int client)
 {
 	if(IsFakeClient(client))
 		return -1;
@@ -927,46 +905,46 @@ GetClientRank(client)
 	return g_iCachedRank[client];
 }
 
-ClearClientRankCache(client)
+void ClearClientRankCache(int client)
 {
 	g_iCachedRank[client] = -1;
 	g_iNextCacheUpdate[client] = 0;
 }
 
-public SQL_GetClientRank(Handle:owner, Handle:hndl, const String:error[], any:userid)
+public void SQL_GetClientRank(Database db, DBResultSet results, const char[] error, any userid)
 {
-	new client = GetClientOfUserId(userid);
+	int client = GetClientOfUserId(userid);
 	if(!client)
 		return;
 	
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Unable to get player rank (%s)", error);
 		return;
 	}
 	
-	if(!SQL_FetchRow(hndl))
+	if(!results.FetchRow())
 		return;
 	
-	g_iCachedRank[client] = SQL_FetchInt(hndl, 0) + 1; // +1 since the query returns the count, not the rank
+	g_iCachedRank[client] = results.FetchInt(0) + 1; // +1 since the query returns the count, not the rank
 	
 	// Save the first time we fetch the rank for him.
 	if(g_iPlayerSessionStartStats[client][SS_JoinRank] == -1)
 		g_iPlayerSessionStartStats[client][SS_JoinRank] = g_iCachedRank[client];
 }
 
-UpdateRankCount()
+void UpdateRankCount()
 {
 	if(!g_hDatabase)
 		return;
 	
-	decl String:sQuery[128];
+	char sQuery[128];
 	Format(sQuery, sizeof(sQuery), "SELECT COUNT(*) FROM %s", TBL_PLAYERS);
-	SQL_TQuery(g_hDatabase, SQL_GetRankCount, sQuery);
+	g_hDatabase.Query(SQL_GetRankCount, sQuery);
 	g_iNextCacheCountUpdate = GetTime() + RANK_CACHE_UPDATE_INTERVAL;
 }
 
-GetRankCount()
+int GetRankCount()
 {
 	// Only update the cache, if we actually used it for a while.
 	if(g_iNextCacheCountUpdate < GetTime())
@@ -978,21 +956,21 @@ GetRankCount()
 	return 0;
 }
 
-public SQL_GetRankCount(Handle:owner, Handle:hndl, const String:error[], any:data)
+public void SQL_GetRankCount(Database db, DBResultSet results, const char[] error, any data)
 {
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Unable to get player rank count (%s)", error);
 		return;
 	}
 	
-	if(!SQL_FetchRow(hndl))
+	if(!results.FetchRow())
 		return;
 	
-	g_iCachedRankCount = SQL_FetchInt(hndl, 0);
+	g_iCachedRankCount = results.FetchInt(0);
 	
-	new info[PlayerInfo];
-	for(new i=1;i<=MaxClients;i++)
+	int info[PlayerInfo];
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i) && !IsFakeClient(i))
 		{
@@ -1003,7 +981,7 @@ public SQL_GetRankCount(Handle:owner, Handle:hndl, const String:error[], any:dat
 	}
 }
 
-PrintRankToChat(client, sendto)
+void PrintRankToChat(int client, int sendto)
 {
 	if(sendto == -1)
 		Client_PrintToChatAll(false, "%t", "rpgrank", client, GetClientLevel(client), GetClientRank(client), GetRankCount(), GetClientExperience(client), Stats_LvlToExp(GetClientLevel(client)), GetClientCredits(client));
@@ -1011,64 +989,64 @@ PrintRankToChat(client, sendto)
 		Client_PrintToChat(sendto, false, "%t", "rpgrank", client, GetClientLevel(client), GetClientRank(client), GetRankCount(), GetClientExperience(client), Stats_LvlToExp(GetClientLevel(client)), GetClientCredits(client));
 }
 
-stock DisplayTop10Menu(client)
+stock void DisplayTop10Menu(int client)
 {
 	if(!g_hDatabase)
 		return; // TODO: Print message about database problems.
 
-	decl String:sQuery[128];
+	char sQuery[128];
 	Format(sQuery, sizeof(sQuery), "SELECT name, level, experience, credits FROM %s ORDER BY level DESC, experience DESC LIMIT 10", TBL_PLAYERS);
-	SQL_TQuery(g_hDatabase, SQL_GetTop10, sQuery, GetClientUserId(client));
+	g_hDatabase.Query(SQL_GetTop10, sQuery, GetClientUserId(client));
 }
 
-public SQL_GetTop10(Handle:owner, Handle:hndl, const String:error[], any:userid)
+public void SQL_GetTop10(Database db, DBResultSet results, const char[] error, any userid)
 {
-	new client = GetClientOfUserId(userid);
+	int client = GetClientOfUserId(userid);
 	if(!client)
 		return;
 	
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Unable to get player top10 (%s)", error);
 		return;
 	}
 	
-	decl String:sBuffer[128];
+	char sBuffer[128];
 	Format(sBuffer, sizeof(sBuffer), "%T\n-----\n", "Top 10 Players", client);
 	
-	new Handle:hPanel = CreatePanel();
-	SetPanelTitle(hPanel, sBuffer);
+	Panel hPanel = new Panel();
+	hPanel.SetTitle(sBuffer);
 	
-	new iIndex = 1;
-	while(SQL_MoreRows(hndl))
+	int iIndex = 1;
+	while(results.MoreRows)
 	{
-		if(!SQL_FetchRow(hndl))
+		if(!results.FetchRow())
 			continue;
 		
-		SQL_FetchString(hndl, 0, sBuffer, sizeof(sBuffer));
-		Format(sBuffer, sizeof(sBuffer), "%d. %s Lvl: %d Exp: %d Cr: %d", iIndex++, sBuffer, SQL_FetchInt(hndl, 1), SQL_FetchInt(hndl, 2), SQL_FetchInt(hndl, 3));
-		DrawPanelText(hPanel, sBuffer);
+		results.FetchString(0, sBuffer, sizeof(sBuffer));
+		Format(sBuffer, sizeof(sBuffer), "%d. %s Lvl: %d Exp: %d Cr: %d", iIndex++, sBuffer, results.FetchInt(1), results.FetchInt(2), results.FetchInt(3));
+		hPanel.DrawText(sBuffer);
 	}
 	
 	// Let the panel close on any number
-	SetPanelKeys(hPanel, 255);
+	hPanel.SetKeys(255);
 	
-	SendPanelToClient(hPanel, client, Panel_DoNothing, MENU_TIME_FOREVER);
-	CloseHandle(hPanel);
+	hPanel.Send(client, Panel_DoNothing, MENU_TIME_FOREVER);
+	delete hPanel;
 }
 
-public Panel_DoNothing(Handle:menu, MenuAction:action, param1, param2)
+public int Panel_DoNothing(Menu menu, MenuAction action, int param1, int param2)
 {
 }
 
-DisplayNextPlayersInRanking(client)
+void DisplayNextPlayersInRanking(int client)
 {
 	if(!g_hDatabase)
 		return; // TODO: Print message about database problems.
 	
-	decl String:sQuery[512];
+	char sQuery[512];
 	Format(sQuery, sizeof(sQuery), "SELECT player_id, name, level, experience, credits, (SELECT COUNT(*) FROM %s ps WHERE p.level < ps.level OR (p.level = ps.level AND p.experience < ps.experience))+1 AS rank FROM %s p WHERE level > %d OR (level = %d AND experience >= %d) ORDER BY level ASC, experience ASC LIMIT 20", TBL_PLAYERS, TBL_PLAYERS, GetClientLevel(client), GetClientLevel(client), GetClientExperience(client));
-	SQL_TQuery(g_hDatabase, SQL_GetNext10, sQuery, GetClientUserId(client));
+	g_hDatabase.Query(SQL_GetNext10, sQuery, GetClientUserId(client));
 }
 
 #define ENUM_STRUCTS_SUCK_SIZE 5+(MAX_NAME_LENGTH+3/4)
@@ -1081,45 +1059,45 @@ enum NextPlayersSorting {
 	String:NP_name[MAX_NAME_LENGTH]
 };
 
-public SQL_GetNext10(Handle:owner, Handle:hndl, const String:error[], any:userid)
+public void SQL_GetNext10(Database db, DBResultSet results, const char[] error, any userid)
 {
-	new client = GetClientOfUserId(userid);
+	int client = GetClientOfUserId(userid);
 	if(!client)
 		return;
 	
-	if(hndl == INVALID_HANDLE || strlen(error) > 0)
+	if(results == null)
 	{
 		LogError("Unable to get the next 20 players in front of the current rank of a player (%s)", error);
 		return;
 	}
 	
-	decl String:sBuffer[128];
+	char sBuffer[128];
 	Format(sBuffer, sizeof(sBuffer), "%T\n-----\n", "Next ranked players", client);
 	
-	new iNextCache[20][ENUM_STRUCTS_SUCK_SIZE], iCount;
+	int iNextCache[20][ENUM_STRUCTS_SUCK_SIZE], iCount;
 	
-	new Handle:hPanel = CreatePanel();
-	SetPanelTitle(hPanel, sBuffer);
+	Panel hPanel = new Panel();
+	hPanel.SetTitle(sBuffer);
 	
-	while(SQL_MoreRows(hndl))
+	while(results.MoreRows)
 	{
-		if(!SQL_FetchRow(hndl))
+		if(!results.FetchRow())
 			continue;
 		
-		SQL_FetchString(hndl, 1, iNextCache[iCount][NP_name], MAX_NAME_LENGTH);
-		iNextCache[iCount][NP_DBID] = SQL_FetchInt(hndl, 0);
-		iNextCache[iCount][NP_level] = SQL_FetchInt(hndl, 2);
-		iNextCache[iCount][NP_exp] = SQL_FetchInt(hndl, 3);
-		iNextCache[iCount][NP_credits] = SQL_FetchInt(hndl, 4);
-		iNextCache[iCount][NP_rank] = SQL_FetchInt(hndl, 5);
+		results.FetchString(1, iNextCache[iCount][NP_name], MAX_NAME_LENGTH);
+		iNextCache[iCount][NP_DBID] = results.FetchInt(0);
+		iNextCache[iCount][NP_level] = results.FetchInt(2);
+		iNextCache[iCount][NP_exp] = results.FetchInt(3);
+		iNextCache[iCount][NP_credits] = results.FetchInt(4);
+		iNextCache[iCount][NP_rank] = results.FetchInt(5);
 		iCount++;
 	}
 	
 	// TODO: Account for currently ingame players that got above us in the ranking and aren't in the db yet, so they aren't in the result set of the query.
 	
 	// See if some players are currently connected and possibly have newer stats in the cache than stored in the db
-	new iLocalPlayer;
-	for(new i=0;i<iCount;i++)
+	int iLocalPlayer;
+	for(int i=0;i<iCount;i++)
 	{
 		iLocalPlayer = GetClientByPlayerID(iNextCache[i][NP_DBID]);
 		if(iLocalPlayer == -1)
@@ -1133,33 +1111,33 @@ public SQL_GetNext10(Handle:owner, Handle:hndl, const String:error[], any:userid
 	SortCustom2D(iNextCache, iCount, Sort2D_NextPlayers);
 	
 	// Save the next rank as reference if the list is reordered with current data below
-	new iLastRank = iNextCache[0][NP_rank];
+	int iLastRank = iNextCache[0][NP_rank];
 	// Fix rank if ordering changed!
-	for(new i=0;i<iCount;i++)
+	for(int i=0;i<iCount;i++)
 	{
 		iNextCache[i][NP_rank] = iLastRank--;
 	}
 	
-	new iNeeded = iCount > 10 ? 10 : iCount;
-	for(new i=0;i<iCount&&iNeeded>0;i++)
+	int iNeeded = iCount > 10 ? 10 : iCount;
+	for(int i=0;i<iCount&&iNeeded>0;i++)
 	{
 		if(iNextCache[i][NP_level] < GetClientLevel(client) || (iNextCache[i][NP_level] == GetClientLevel(client) && iNextCache[i][NP_exp] < GetClientExperience(client)))
 			continue;
 		
 		Format(sBuffer, sizeof(sBuffer), "%d. %s Lvl: %d Exp: %d Cr: %d", iNextCache[i][NP_rank], iNextCache[i][NP_name], iNextCache[i][NP_level], iNextCache[i][NP_exp], iNextCache[i][NP_credits]);
-		DrawPanelText(hPanel, sBuffer);
+		hPanel.DrawText(sBuffer);
 		iNeeded--;
 	}
 	
 	// Let the panel close on any number
-	SetPanelKeys(hPanel, 255);
+	hPanel.SetKeys(255);
 	
-	SendPanelToClient(hPanel, client, Panel_DoNothing, MENU_TIME_FOREVER);
-	CloseHandle(hPanel);
+	hPanel.Send(client, Panel_DoNothing, MENU_TIME_FOREVER);
+	delete hPanel;
 }
 
 // Sort players ascending by level and experience
-public Sort2D_NextPlayers(elem1[], elem2[], const array[][], Handle:hndl)
+public int Sort2D_NextPlayers(int[] elem1, int[] elem2, const int[][] array, Handle hndl)
 {
 	if(elem1[NP_level] > elem2[NP_level])
 		return 1;
@@ -1173,88 +1151,89 @@ public Sort2D_NextPlayers(elem1[], elem2[], const array[][], Handle:hndl)
 /**
  * Extra experience per weapon parsing
  */
-InitWeaponExperienceConfig()
+void InitWeaponExperienceConfig()
 {
-	g_hWeaponExperience = CreateTrie();
+	g_hWeaponExperience = new StringMap();
 }
 
-bool:ReadWeaponExperienceConfig()
+bool ReadWeaponExperienceConfig()
 {
 	// Clear all the previous configs first.
-	ClearTrie(g_hWeaponExperience);
+	g_hWeaponExperience.Clear();
 	
-	decl String:sPath[PLATFORM_MAX_PATH];
+	char sPath[PLATFORM_MAX_PATH];
 	BuildPath(Path_SM, sPath, sizeof(sPath), "configs/smrpg/weapon_experience.cfg");
 	
 	if(!FileExists(sPath))
 		return false;
 	
-	new Handle:hKV = CreateKeyValues("SMRPGWeaponExperience");
-	if(!FileToKeyValues(hKV, sPath))
+	KeyValues hKV = CreateKeyValues("SMRPGWeaponExperience");
+	if(!hKV.ImportFromFile(sPath))
 	{
-		CloseHandle(hKV);
+		delete hKV;
 		return false;
 	}
 	
-	if(!KvGotoFirstSubKey(hKV))
+	if(!hKV.GotoFirstSubKey())
 	{
-		CloseHandle(hKV);
+		delete hKV;
 		return false;
 	}
 	
-	new String:sWeapon[64], iWeaponExperience[WeaponExperienceContainer];
+	char sWeapon[64];
+	int iWeaponExperience[WeaponExperienceContainer];
 	do {
-		KvGetSectionName(hKV, sWeapon, sizeof(sWeapon));
+		hKV.GetSectionName(sWeapon, sizeof(sWeapon));
 		RemovePrefixFromString("weapon_", sWeapon, sWeapon, sizeof(sWeapon));
 	
-		iWeaponExperience[WXP_Damage] = KvGetFloat(hKV, "exp_damage", -1.0);
-		iWeaponExperience[WXP_Kill] = KvGetFloat(hKV, "exp_kill", -1.0);
-		iWeaponExperience[WXP_Bonus] = KvGetFloat(hKV, "exp_bonus", -1.0);
+		iWeaponExperience[WXP_Damage] = hKV.GetFloat("exp_damage", -1.0);
+		iWeaponExperience[WXP_Kill] = hKV.GetFloat("exp_kill", -1.0);
+		iWeaponExperience[WXP_Bonus] = hKV.GetFloat("exp_bonus", -1.0);
 		
-		SetTrieArray(g_hWeaponExperience, sWeapon, iWeaponExperience[0], _:WeaponExperienceContainer);
+		g_hWeaponExperience.SetArray(sWeapon, iWeaponExperience[0], view_as<int>(WeaponExperienceContainer));
 		
-	} while(KvGotoNextKey(hKV));
+	} while(hKV.GotoNextKey());
 	
-	CloseHandle(hKV);
+	delete hKV;
 	return true;
 }
 
-Float:GetWeaponExperience(const String:sWeapon[], WeaponExperienceType:type)
+float GetWeaponExperience(const char[] sWeapon, WeaponExperienceType type)
 {
-	new iWeaponExperience[WeaponExperienceContainer];
+	int iWeaponExperience[WeaponExperienceContainer];
 	iWeaponExperience[WXP_Damage] = -1.0;
 	iWeaponExperience[WXP_Kill] = -1.0;
 	iWeaponExperience[WXP_Bonus] = -1.0;
 	
-	new String:sBuffer[64];
+	char sBuffer[64];
 	RemovePrefixFromString("weapon_", sWeapon, sBuffer, sizeof(sBuffer));
 	// We default back to the convar values, if this fails.
-	GetTrieArray(g_hWeaponExperience, sBuffer, iWeaponExperience[0], _:WeaponExperienceContainer);
+	g_hWeaponExperience.GetArray(sBuffer, iWeaponExperience[0], view_as<int>(WeaponExperienceContainer));
 	
 	// Fall back to default convar values, if unset or invalid.
 	if(iWeaponExperience[WXP_Damage] < 0.0)
-		iWeaponExperience[WXP_Damage] = GetConVarFloat(g_hCVExpDamage);
+		iWeaponExperience[WXP_Damage] = g_hCVExpDamage.FloatValue;
 	if(iWeaponExperience[WXP_Kill] < 0.0)
-		iWeaponExperience[WXP_Kill] = GetConVarFloat(g_hCVExpKill);
+		iWeaponExperience[WXP_Kill] = g_hCVExpKill.FloatValue;
 	if(iWeaponExperience[WXP_Bonus] < 0.0)
-		iWeaponExperience[WXP_Bonus] = GetConVarFloat(g_hCVExpKillBonus);
+		iWeaponExperience[WXP_Bonus] = g_hCVExpKillBonus.FloatValue;
 	
-	return Float:iWeaponExperience[type];
+	return view_as<float>(iWeaponExperience[type]);
 }
 
 /**
  * Helper functions
  */
 // Taken from SourceBans 2's sb_bans :)
-SecondsToString(String:sBuffer[], iLength, iSecs, bool:bTextual = true)
+void SecondsToString(char[] sBuffer, int iLength, int iSecs, bool bTextual = true)
 {
 	if(bTextual)
 	{
-		decl String:sDesc[6][8] = {"mo",              "wk",             "d",          "hr",    "min", "sec"};
-		new  iCount, iDiv[6]    = {60 * 60 * 24 * 30, 60 * 60 * 24 * 7, 60 * 60 * 24, 60 * 60, 60,    1};
+		char sDesc[6][8] = {"mo",              "wk",             "d",          "hr",    "min", "sec"};
+		int  iCount, iDiv[6]    = {60 * 60 * 24 * 30, 60 * 60 * 24 * 7, 60 * 60 * 24, 60 * 60, 60,    1};
 		sBuffer[0]              = '\0';
 		
-		for(new i = 0; i < sizeof(iDiv); i++)
+		for(int i = 0; i < sizeof(iDiv); i++)
 		{
 			if((iCount = iSecs / iDiv[i]) > 0)
 			{
@@ -1266,9 +1245,9 @@ SecondsToString(String:sBuffer[], iLength, iSecs, bool:bTextual = true)
 	}
 	else
 	{
-		new iHours = iSecs  / 60 / 60;
+		int iHours = iSecs  / 60 / 60;
 		iSecs     -= iHours * 60 * 60;
-		new iMins  = iSecs  / 60;
+		int iMins  = iSecs  / 60;
 		iSecs     %= 60;
 		Format(sBuffer, iLength, "%02i:%02i:%02i", iHours, iMins, iSecs);
 	}
@@ -1276,9 +1255,9 @@ SecondsToString(String:sBuffer[], iLength, iSecs, bool:bTextual = true)
 
 // This removes a prefix from a string including anything before the prefix.
 // This is useful for TF2's tfweapon_ prefix vs. default weapon_ prefix in other sourcegames.
-stock RemovePrefixFromString(const String:sPrefix[], const String:sInput[], String:sOutput[], maxlen)
+stock void RemovePrefixFromString(const char[] sPrefix, const char[] sInput, char[] sOutput, int maxlen)
 {
-	new iPos = StrContains(sInput, sPrefix, false);
+	int iPos = StrContains(sInput, sPrefix, false);
 	// The prefix isn't in the string, just copy the whole string.
 	if(iPos == -1)
 		iPos = 0;
@@ -1287,7 +1266,7 @@ stock RemovePrefixFromString(const String:sPrefix[], const String:sInput[], Stri
 		iPos += strlen(sPrefix);
 	
 	// Support for inputstring == outputstring?
-	new String:sBuffer[maxlen+1];
+	char[] sBuffer = new char[maxlen+1];
 	strcopy(sBuffer, maxlen, sInput[iPos]);
 	
 	strcopy(sOutput, maxlen, sBuffer);

--- a/scripting/smrpg_antisuicide.sp
+++ b/scripting/smrpg_antisuicide.sp
@@ -4,10 +4,11 @@
 #include <smrpg>
 #include <smlib>
 
+#pragma newdecls required
 #define PLUGIN_VERSION "1.0"
 
-new Handle:g_hCVLastAttackSince;
-new Handle:g_hCVExpPunish;
+ConVar g_hCVLastAttackSince;
+ConVar g_hCVExpPunish;
 
 enum HitInfo {
 	HI_attacker,
@@ -15,9 +16,9 @@ enum HitInfo {
 	HI_lastattack
 };
 
-new Handle:g_hHitInfo[MAXPLAYERS+1];
+ArrayList g_hHitInfo[MAXPLAYERS+1];
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG > Anti-Selfkill",
 	author = "Peace-Maker",
@@ -26,13 +27,13 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
-	new Handle:hVersion = CreateConVar("smrpg_antiselfkill_version", PLUGIN_VERSION, "", FCVAR_NOTIFY|FCVAR_DONTRECORD);
-	if(hVersion != INVALID_HANDLE)
+	ConVar hVersion = CreateConVar("smrpg_antiselfkill_version", PLUGIN_VERSION, "", FCVAR_NOTIFY|FCVAR_DONTRECORD);
+	if(hVersion != null)
 	{
-		SetConVarString(hVersion, PLUGIN_VERSION);
-		HookConVarChange(hVersion, ConVar_VersionChanged);
+		hVersion.SetString(PLUGIN_VERSION);
+		hVersion.AddChangeHook(ConVar_VersionChanged);
 	}
 	
 	g_hCVLastAttackSince = CreateConVar("smrpg_antiselfkill_lastattack", "10", "Only take experience, if the selfkiller got attacked by someone in the last x seconds.", _, true, 0.0);
@@ -44,59 +45,59 @@ public OnPluginStart()
 	HookEvent("player_spawn", Event_OnPlayerSpawn);
 }
 
-public ConVar_VersionChanged(Handle:convar, const String:oldValue[], const String:newValue[])
+public void ConVar_VersionChanged(ConVar convar, const char[] oldValue, const char[] newValue)
 {
-	SetConVarString(convar, PLUGIN_VERSION);
+	convar.SetString(PLUGIN_VERSION);
 }
 
 /**
  * Public global forwards
  */
-public OnClientPutInServer(client)
+public void OnClientPutInServer(int client)
 {
-	g_hHitInfo[client] = CreateArray(_:HitInfo);
+	g_hHitInfo[client] = new ArrayList(view_as<int>(HitInfo));
 	SDKHook(client, SDKHook_OnTakeDamagePost, Hook_OnTakeDamagePost);
 }
 
-public OnClientDisconnect(client)
+public void OnClientDisconnect(int client)
 {
-	if(g_hHitInfo[client] != INVALID_HANDLE)
+	if(g_hHitInfo[client] != null)
 		CloseHandle(g_hHitInfo[client]);
-	g_hHitInfo[client] = INVALID_HANDLE;
+	g_hHitInfo[client] = null;
 }
 
 
 /**
  * Event callbacks
  */
-public Event_OnPlayerSpawn(Handle:event, const String:name[], bool:dontBroadcast)
+public void Event_OnPlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(!client)
 		return;
 	
 	// Forget every previous damage
-	ClearArray(g_hHitInfo[client]);
+	g_hHitInfo[client].Clear();
 }
 
 
-public Event_OnPlayerDeath(Handle:event, const String:name[], bool:dontBroadcast)
+public void Event_OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 {
-	new victim = GetClientOfUserId(GetEventInt(event, "userid"));
+	int victim = GetClientOfUserId(event.GetInt("userid"));
 	if(!victim)
 		return;
 	
-	new iSize = GetArraySize(g_hHitInfo[victim]);
+	int iSize = g_hHitInfo[victim].Length;
 	// Make sure he got attacked before
 	if(!iSize)
 		return;
 	
-	new attacker = GetClientOfUserId(GetEventInt(event, "attacker"));
+	int attacker = GetClientOfUserId(event.GetInt("attacker"));
 	
 	// Don't care for regular frags.
 	if(!attacker || victim != attacker)
 	{
-		ClearArray(g_hHitInfo[victim]);
+		g_hHitInfo[victim].Clear();
 		return;
 	}
 	
@@ -104,22 +105,22 @@ public Event_OnPlayerDeath(Handle:event, const String:name[], bool:dontBroadcast
 	// Find the attacker, who did the most damage
 	SortADTArrayCustom(g_hHitInfo[victim], ADT_SortHitInfoByDamage);
 	
-	new eHitInfo[HitInfo];
-	GetArrayArray(g_hHitInfo[victim], 0, eHitInfo[0], _:HitInfo);
+	int eHitInfo[HitInfo];
+	g_hHitInfo[victim].GetArray(0, eHitInfo[0], view_as<int>(HitInfo));
 	
 	// TODO: Give regular kill experience to last attacker.
 	
 	// Take some exp from the selfkiller
 	SortADTArrayCustom(g_hHitInfo[victim], ADT_SortHitInfoByAttacktime);
-	GetArrayArray(g_hHitInfo[victim], 0, eHitInfo[0], _:HitInfo);
+	g_hHitInfo[victim].GetArray(0, eHitInfo[0], view_as<int>(HitInfo));
 	
 	// Make sure he got attacked not long ago and might prevented that attacker from earning experience for a kill.
-	new iLastAttackSince = GetConVarInt(g_hCVLastAttackSince);
+	int iLastAttackSince = g_hCVLastAttackSince.IntValue;
 	if(iLastAttackSince == 0 || (GetTime() - eHitInfo[HI_lastattack]) < iLastAttackSince)
 	{
-		new iNeededExp = SMRPG_LevelToExperience(SMRPG_GetClientLevel(victim));
-		new iReducedExp = RoundToCeil(iNeededExp * GetConVarFloat(g_hCVExpPunish));
-		new iExp = SMRPG_GetClientExperience(victim);
+		int iNeededExp = SMRPG_LevelToExperience(SMRPG_GetClientLevel(victim));
+		int iReducedExp = RoundToCeil(iNeededExp * g_hCVExpPunish.FloatValue);
+		int iExp = SMRPG_GetClientExperience(victim);
 		if(iReducedExp > iExp)
 			iReducedExp = iExp;
 		SMRPG_SetClientExperience(victim, iExp - iReducedExp);
@@ -127,22 +128,22 @@ public Event_OnPlayerDeath(Handle:event, const String:name[], bool:dontBroadcast
 		LogMessage("%L lost %d experience for suiciding. (now %d/%d)", victim, iReducedExp, SMRPG_GetClientExperience(victim), iNeededExp);
 	}
 	
-	ClearArray(g_hHitInfo[victim]);
+	g_hHitInfo[victim].Clear();
 }
 
 /**
  * SDK Hooks callbacks
  */
-public Hook_OnTakeDamagePost(victim, attacker, inflictor, Float:damage, damagetype, weapon, const Float:damageForce[3], const Float:damagePosition[3])
+public void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3])
 {
 	if(victim <= 0 || victim > MaxClients || attacker <= 0 || attacker > MaxClients)
 		return;
 	
-	new eHitInfo[HitInfo], iIndex = -1;
-	new iSize = GetArraySize(g_hHitInfo[victim]);
-	for(new i=0;i<iSize;i++)
+	int eHitInfo[HitInfo], iIndex = -1;
+	int iSize = g_hHitInfo[victim].Length;
+	for(int i=0;i<iSize;i++)
 	{
-		GetArrayArray(g_hHitInfo[victim], i, eHitInfo[0], _:HitInfo);
+		g_hHitInfo[victim].GetArray(i, eHitInfo[0], view_as<int>(HitInfo));
 		// Search the old hitinfo of this attacker
 		if(eHitInfo[HI_attacker] != attacker)
 			continue;
@@ -158,33 +159,35 @@ public Hook_OnTakeDamagePost(victim, attacker, inflictor, Float:damage, damagety
 	if(iIndex == -1)
 	{
 		eHitInfo[HI_damage] = damage;
-		PushArrayArray(g_hHitInfo[victim], eHitInfo[0], _:HitInfo);
+		g_hHitInfo[victim].PushArray(eHitInfo[0], view_as<int>(HitInfo));
 	}
 	// Already damaged him before.
 	else
 	{
 		eHitInfo[HI_damage] += damage;
-		SetArrayArray(g_hHitInfo[victim], iIndex, eHitInfo[0], _:HitInfo);
+		g_hHitInfo[victim].SetArray(iIndex, eHitInfo[0], view_as<int>(HitInfo));
 	}
 }
 
 /**
  * Misc ADT array sorting
  */
-public ADT_SortHitInfoByDamage(index1, index2, Handle:array, Handle:hndl)
+public int ADT_SortHitInfoByDamage(int index1, int index2, Handle array, Handle hndl)
 {
-	new eHitInfo1[HitInfo], eHitInfo2[HitInfo];
-	GetArrayArray(array, index1, eHitInfo1[0], _:HitInfo);
-	GetArrayArray(array, index2, eHitInfo2[0], _:HitInfo);
+	int eHitInfo1[HitInfo], eHitInfo2[HitInfo];
+	ArrayList arrayList = view_as<ArrayList>(array);
+	arrayList.GetArray(index1, eHitInfo1[0], view_as<int>(HitInfo));
+	arrayList.GetArray(index2, eHitInfo2[0], view_as<int>(HitInfo));
 	
 	return RoundToCeil(eHitInfo2[HI_damage] - eHitInfo1[HI_damage]);
 }
 
-public ADT_SortHitInfoByAttacktime(index1, index2, Handle:array, Handle:hndl)
+public int ADT_SortHitInfoByAttacktime(int index1, int index2, Handle array, Handle hndl)
 {
-	new eHitInfo1[HitInfo], eHitInfo2[HitInfo];
-	GetArrayArray(array, index1, eHitInfo1[0], _:HitInfo);
-	GetArrayArray(array, index2, eHitInfo2[0], _:HitInfo);
+	int eHitInfo1[HitInfo], eHitInfo2[HitInfo];
+	ArrayList arrayList = view_as<ArrayList>(array);
+	arrayList.GetArray(index1, eHitInfo1[0], view_as<int>(HitInfo));
+	arrayList.GetArray(index2, eHitInfo2[0], view_as<int>(HitInfo));
 	
 	return eHitInfo2[HI_lastattack] - eHitInfo1[HI_lastattack];
 }

--- a/scripting/smrpg_cstrike.sp
+++ b/scripting/smrpg_cstrike.sp
@@ -292,7 +292,7 @@ public void Event_OnPlayerDeath(Event event, const char[] error, bool dontBroadc
 		return;
 	
 	char sWeapon[64];
-	GetEventString(event, "weapon", sWeapon, sizeof(sWeapon));
+	event.GetString("weapon", sWeapon, sizeof(sWeapon));
 	
 	int iExp = RoundToCeil(SMRPG_GetClientLevel(victim) * SMRPG_GetWeaponExperience(sWeapon, WeaponExperience_Kill) + SMRPG_GetWeaponExperience(sWeapon, WeaponExperience_Bonus));
 	if(GetEventBool(event, "headshot"))

--- a/scripting/smrpg_cstrike.sp
+++ b/scripting/smrpg_cstrike.sp
@@ -6,32 +6,33 @@
 #include <smlib>
 #include <autoexecconfig>
 
+#pragma newdecls required
 #define PLUGIN_VERSION "1.0"
 
 //#define _DEBUG
 
-new bool:g_bIsCSGO;
+bool g_bIsCSGO;
 
-new Handle:g_hCVExpKillMax;
-new Handle:g_hCVExpTeamwin;
+ConVar g_hCVExpKillMax;
+ConVar g_hCVExpTeamwin;
 
-new Handle:g_hCVExpKillAssist;
+ConVar g_hCVExpKillAssist;
 
-new Handle:g_hCVExpHeadshot;
+ConVar g_hCVExpHeadshot;
 
-new Handle:g_hCVExpBombPlanted;
-new Handle:g_hCVExpBombDefused;
-new Handle:g_hCVExpBombExploded;
-new Handle:g_hCVExpHostage;
-new Handle:g_hCVExpVIPEscaped;
+ConVar g_hCVExpBombPlanted;
+ConVar g_hCVExpBombDefused;
+ConVar g_hCVExpBombExploded;
+ConVar g_hCVExpHostage;
+ConVar g_hCVExpVIPEscaped;
 
-new Handle:g_hCVExpDominating;
-new Handle:g_hCVExpRevenge;
+ConVar g_hCVExpDominating;
+ConVar g_hCVExpRevenge;
 
-new Handle:g_hCVBotEarnExpObjective;
+ConVar g_hCVBotEarnExpObjective;
 
-new Handle:g_hCVShowMVPLevel;
-new Handle:g_hCVEnableAntiKnifeleveling;
+ConVar g_hCVShowMVPLevel;
+ConVar g_hCVEnableAntiKnifeleveling;
 
 enum KnifeLeveling {
 	KL_Hits,
@@ -39,12 +40,12 @@ enum KnifeLeveling {
 	KL_FirstAttack
 };
 
-new g_iKnifeDamage[MAXPLAYERS+1][MAXPLAYERS+1][KnifeLeveling];
-new bool:g_bKnifeLeveled[MAXPLAYERS+1];
-new Handle:g_hKnifeLevelCooldown[MAXPLAYERS+1];
-new g_iKnifeLevelDetections[MAXPLAYERS+1];
+int g_iKnifeDamage[MAXPLAYERS+1][MAXPLAYERS+1][KnifeLeveling];
+bool g_bKnifeLeveled[MAXPLAYERS+1];
+Handle g_hKnifeLevelCooldown[MAXPLAYERS+1];
+int g_iKnifeLevelDetections[MAXPLAYERS+1];
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG > Counter-Strike Experience Module",
 	author = "Jannik \"Peace-Maker\" Hartung, SeLfkiLL",
@@ -53,9 +54,9 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
-	new EngineVersion:engine = GetEngineVersion();
+	EngineVersion engine = GetEngineVersion();
 	if(engine != Engine_CSS && engine != Engine_CSGO)
 	{
 		Format(error, err_max, "This plugin is for use in Counter-Strike only. Bad engine version %d.", engine);
@@ -67,11 +68,11 @@ public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
 	return APLRes_Success;
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	AutoExecConfig_SetFile("plugin.smrpg_cstrike");
 	AutoExecConfig_SetCreateFile(true);
-	AutoExecConfig_SetPlugin(INVALID_HANDLE);
+	AutoExecConfig_SetPlugin(null);
 	
 	g_hCVExpKillAssist = AutoExecConfig_CreateConVar("smrpg_exp_kill_assist", "10.0", "Experience for assisting in killing a player multiplied by the victim's level", 0, true, 0.0);
 	
@@ -109,20 +110,20 @@ public OnPluginStart()
 	HookEvent("round_mvp", Event_OnRoundMVP);
 }
 
-public OnAllPluginsLoaded()
+public void OnAllPluginsLoaded()
 {
 	g_hCVExpKillMax = FindConVar("smrpg_exp_kill_max");
 	g_hCVExpTeamwin = FindConVar("smrpg_exp_teamwin");
 }
 
 // Reset anti knifeleveling stuff
-public OnClientDisconnect(client)
+public void OnClientDisconnect(int client)
 {
 	g_bKnifeLeveled[client] = false;
 	ClearHandle(g_hKnifeLevelCooldown[client]);
 	g_iKnifeLevelDetections[client] = 0;
 	
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		g_iKnifeDamage[client][i][KL_Hits] = 0;
 		g_iKnifeDamage[client][i][KL_LastAttack] = 0;
@@ -134,7 +135,7 @@ public OnClientDisconnect(client)
 	}
 }
 
-public Action:SMRPG_OnAddExperience(client, const String:reason[], &iExperience, other)
+public Action SMRPG_OnAddExperience(int client, const char[] reason, int &iExperience, int other)
 {
 	// Don't let the normal experience calculation hit. We're doing some cstrike specific stuff here.
 	if(StrEqual(reason, ExperienceReason_PlayerHurt) || StrEqual(reason, ExperienceReason_PlayerKill) || StrEqual(reason, ExperienceReason_RoundEnd))
@@ -143,7 +144,7 @@ public Action:SMRPG_OnAddExperience(client, const String:reason[], &iExperience,
 	return Plugin_Continue;
 }
 
-public Action:SMRPG_OnClientLevel(client, oldlevel, newlevel)
+public Action SMRPG_OnClientLevel(int client, int oldlevel, int newlevel)
 {
 	if(IsClientInGame(client))
 		UpdateMVPLevel(client);
@@ -151,7 +152,7 @@ public Action:SMRPG_OnClientLevel(client, oldlevel, newlevel)
 	return Plugin_Continue;
 }
 
-public SMRPG_TranslateExperienceReason(client, const String:reason[], iExperience, other, String:buffer[], maxlen)
+public void SMRPG_TranslateExperienceReason(int client, const char[] reason, int iExperience, int other, char[] buffer, int maxlen)
 {
 	// Just use the reason string directly as translation phrase.
 	if(other > 0)
@@ -160,27 +161,27 @@ public SMRPG_TranslateExperienceReason(client, const String:reason[], iExperienc
 		Format(buffer, maxlen, "%T", reason, client, iExperience);
 }
 
-public Event_OnPlayerSpawn(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnPlayerSpawn(Event event, const char[] error, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	UpdateMVPLevel(client);
 }
 
-public Event_OnRoundMVP(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnRoundMVP(Event event, const char[] error, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	UpdateMVPLevel(client);
 }
 
-public Event_OnPlayerHurt(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnPlayerHurt(Event event, const char[] error, bool dontBroadcast)
 {
-	new attacker = GetClientOfUserId(GetEventInt(event, "attacker"));
-	new victim = GetClientOfUserId(GetEventInt(event, "userid"));
+	int attacker = GetClientOfUserId(event.GetInt("attacker"));
+	int victim = GetClientOfUserId(event.GetInt("userid"));
 	
-	new iDmgHealth = GetEventInt(event, "dmg_health");
-	new iDmgArmor = GetEventInt(event, "dmg_armor");
-	decl String:sWeapon[64];
-	GetEventString(event, "weapon", sWeapon, sizeof(sWeapon));
+	int iDmgHealth = event.GetInt("dmg_health");
+	int iDmgArmor = event.GetInt("dmg_armor");
+	char sWeapon[64];
+	event.GetString("weapon", sWeapon, sizeof(sWeapon));
 	
 	if(attacker == 0 || victim == 0)
 		return;
@@ -199,8 +200,8 @@ public Event_OnPlayerHurt(Handle:event, const String:error[], bool:dontBroadcast
 	if(!SMRPG_IsFFAEnabled() && GetClientTeam(attacker) == GetClientTeam(victim))
 		return;
 	
-	new iExp;
-	new iTotalDmg = iDmgHealth+iDmgArmor;
+	int iExp;
+	int iTotalDmg = iDmgHealth+iDmgArmor;
 	if(StrContains(sWeapon, "knife") != -1)
 	{
 		// If this guy didn't attack the other player for 30 seconds, reset his hit count.
@@ -221,7 +222,7 @@ public Event_OnPlayerHurt(Handle:event, const String:error[], bool:dontBroadcast
 		if(g_iKnifeDamage[attacker][victim][KL_Hits] > 5 && (g_iKnifeDamage[attacker][victim][KL_LastAttack] - g_iKnifeDamage[attacker][victim][KL_FirstAttack]) > 10)
 		{
 			//PrintToServer("%N is knifeleveling on %N. hits %d, time since first attack: %d", attacker, victim, g_iKnifeDamage[attacker][victim][KL_Hits], (g_iKnifeDamage[attacker][victim][KL_LastAttack] - g_iKnifeDamage[attacker][victim][KL_FirstAttack]));
-			if(GetConVarBool(g_hCVEnableAntiKnifeleveling) && !g_bKnifeLeveled[attacker])
+			if(g_hCVEnableAntiKnifeleveling.BoolValue && !g_bKnifeLeveled[attacker])
 			{
 				LogMessage("%L (lvl %d) is knifeleveling with %L (lvl %d).", attacker, SMRPG_GetClientLevel(attacker), victim, SMRPG_GetClientLevel(victim));
 				Client_PrintToChatAll(false, "%t", "Player is knifeleveling", attacker, victim);
@@ -237,7 +238,7 @@ public Event_OnPlayerHurt(Handle:event, const String:error[], bool:dontBroadcast
 		}
 		
 		// Don't give any experience at all for knife leveling.
-		if(GetConVarBool(g_hCVEnableAntiKnifeleveling) && g_bKnifeLeveled[attacker])
+		if(g_hCVEnableAntiKnifeleveling.BoolValue && g_bKnifeLeveled[attacker])
 			return;
 
 	}
@@ -250,18 +251,18 @@ public Event_OnPlayerHurt(Handle:event, const String:error[], bool:dontBroadcast
 		Debug_AddClientExperience(attacker, iExp, true, "cs_playerhurt", victim);
 }
 
-public Event_OnPlayerDeath(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnPlayerDeath(Event event, const char[] error, bool dontBroadcast)
 {
-	new attacker = GetClientOfUserId(GetEventInt(event, "attacker"));
-	new victim = GetClientOfUserId(GetEventInt(event, "userid"));
-	new assister;
+	int attacker = GetClientOfUserId(event.GetInt("attacker"));
+	int victim = GetClientOfUserId(event.GetInt("userid"));
+	int assister;
 	
 	if(attacker == 0 || victim == 0)
 		return;
 	
 	if(g_bIsCSGO)
 	{
-		assister = GetClientOfUserId(GetEventInt(event, "assister"));
+		assister = GetClientOfUserId(event.GetInt("assister"));
 	}
 	
 	if(!SMRPG_IsEnabled())
@@ -278,7 +279,7 @@ public Event_OnPlayerDeath(Handle:event, const String:error[], bool:dontBroadcas
 	if(assister > 0
 	&& (SMRPG_IsFFAEnabled() || GetClientTeam(victim) != GetClientTeam(assister)))
 	{
-		new iExp = RoundToCeil(SMRPG_GetClientLevel(victim) * GetConVarFloat(g_hCVExpKillAssist));
+		int iExp = RoundToCeil(SMRPG_GetClientLevel(victim) * g_hCVExpKillAssist.FloatValue);
 		Debug_AddClientExperience(assister, iExp, false, "cs_playerkillassist", victim);
 	}
 	
@@ -290,14 +291,14 @@ public Event_OnPlayerDeath(Handle:event, const String:error[], bool:dontBroadcas
 	if(!SMRPG_IsFFAEnabled() && GetClientTeam(attacker) == GetClientTeam(victim))
 		return;
 	
-	new String:sWeapon[64];
+	char sWeapon[64];
 	GetEventString(event, "weapon", sWeapon, sizeof(sWeapon));
 	
-	new iExp = RoundToCeil(SMRPG_GetClientLevel(victim) * SMRPG_GetWeaponExperience(sWeapon, WeaponExperience_Kill) + SMRPG_GetWeaponExperience(sWeapon, WeaponExperience_Bonus));
+	int iExp = RoundToCeil(SMRPG_GetClientLevel(victim) * SMRPG_GetWeaponExperience(sWeapon, WeaponExperience_Kill) + SMRPG_GetWeaponExperience(sWeapon, WeaponExperience_Bonus));
 	if(GetEventBool(event, "headshot"))
-		iExp += GetConVarInt(g_hCVExpHeadshot);
+		iExp += g_hCVExpHeadshot.IntValue;
 	
-	new iExpMax = GetConVarInt(g_hCVExpKillMax);
+	int iExpMax = g_hCVExpKillMax.IntValue;
 	// Limit the possible experience to this.
 	if(iExpMax > 0 && iExp > iExpMax)
 		iExp = iExpMax;
@@ -307,14 +308,14 @@ public Event_OnPlayerDeath(Handle:event, const String:error[], bool:dontBroadcas
 	// Player started dominating this player?
 	if(GetEventBool(event, "dominated"))
 	{
-		iExp = RoundToCeil(SMRPG_GetClientLevel(victim) * GetConVarFloat(g_hCVExpDominating));
+		iExp = RoundToCeil(SMRPG_GetClientLevel(victim) * g_hCVExpDominating.FloatValue);
 		Debug_AddClientExperience(attacker, iExp, false, "cs_dominating", victim);
 	}
 	
 	// Player broke the domination and killed him in revenge?
 	if(GetEventBool(event, "revenge"))
 	{
-		iExp = RoundToCeil(SMRPG_GetClientLevel(victim) * GetConVarFloat(g_hCVExpRevenge));
+		iExp = RoundToCeil(SMRPG_GetClientLevel(victim) * g_hCVExpRevenge.FloatValue);
 		Debug_AddClientExperience(attacker, iExp, false, "cs_revenge", victim);
 	}
 }
@@ -328,10 +329,10 @@ public Event_OnPlayerDeath(Handle:event, const String:error[], bool:dontBroadcas
 	11   Target has been saved!
 	12   Hostages have not been rescued!
 */
-public Event_OnRoundEnd(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnRoundEnd(Event event, const char[] error, bool dontBroadcast)
 {
-	new iTeam = GetEventInt(event, "winner");
-	new CSRoundEndReason:iReason = CSRoundEndReason:GetEventInt(event, "reason");
+	int iTeam = event.GetInt("winner");
+	CSRoundEndReason iReason = view_as<CSRoundEndReason>(event.GetInt("reason"));
 	
 	// The reasons in CS:GO are shifted in the CSRoundEndReason enum..
 	if (g_bIsCSGO)
@@ -349,7 +350,7 @@ public Event_OnRoundEnd(Handle:event, const String:error[], bool:dontBroadcast)
 			return;
 	}
 	
-	new Float:fTeamRatio;
+	float fTeamRatio;
 	if(iTeam == 2)
 		fTeamRatio = SMRPG_TeamRatio(3);
 	else if(iTeam == 3)
@@ -357,128 +358,128 @@ public Event_OnRoundEnd(Handle:event, const String:error[], bool:dontBroadcast)
 	else
 		return;
 	
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i) && GetClientTeam(i) == iTeam)
-			Debug_AddClientExperience(i, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(i))) * GetConVarFloat(g_hCVExpTeamwin) * fTeamRatio), false, "cs_winround");
+			Debug_AddClientExperience(i, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(i))) * g_hCVExpTeamwin.FloatValue * fTeamRatio), false, "cs_winround");
 	}
 }
 
-public Event_OnBombPlanted(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnBombPlanted(Event event, const char[] error, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(!client)
 		return;
 	
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	new iTeam = GetClientTeam(client);
+	int iTeam = GetClientTeam(client);
 	if(iTeam <= 1)
 		return;
 	
-	if(IsFakeClient(client) && !GetConVarBool(g_hCVBotEarnExpObjective))
+	if(IsFakeClient(client) && !g_hCVBotEarnExpObjective.BoolValue)
 		return;
 	
-	new Float:fTeamRatio = SMRPG_TeamRatio(iTeam == 2 ? 3 : 2);
-	Debug_AddClientExperience(client, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(client))) * GetConVarFloat(g_hCVExpBombPlanted) * fTeamRatio), false, "cs_bombplanted");
+	float fTeamRatio = SMRPG_TeamRatio(iTeam == 2 ? 3 : 2);
+	Debug_AddClientExperience(client, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(client))) * g_hCVExpBombPlanted.FloatValue * fTeamRatio), false, "cs_bombplanted");
 }
 
-public Event_OnBombDefused(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnBombDefused(Event event, const char[] error, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(!client)
 		return;
 	
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	new iTeam = GetClientTeam(client);
+	int iTeam = GetClientTeam(client);
 	if(iTeam <= 1)
 		return;
 	
-	if(IsFakeClient(client) && !GetConVarBool(g_hCVBotEarnExpObjective))
+	if(IsFakeClient(client) && !g_hCVBotEarnExpObjective.BoolValue)
 		return;
 	
-	new Float:fTeamRatio = SMRPG_TeamRatio(iTeam == 2 ? 3 : 2);
-	Debug_AddClientExperience(client, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(client))) * GetConVarFloat(g_hCVExpBombDefused) * fTeamRatio), false, "cs_bombdefused");
+	float fTeamRatio = SMRPG_TeamRatio(iTeam == 2 ? 3 : 2);
+	Debug_AddClientExperience(client, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(client))) * g_hCVExpBombDefused.FloatValue * fTeamRatio), false, "cs_bombdefused");
 }
 
-public Event_OnBombExploded(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnBombExploded(Event event, const char[] error, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(!client)
 		return;
 	
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	new iTeam = GetClientTeam(client);
+	int iTeam = GetClientTeam(client);
 	if(iTeam <= 1)
 		return;
 	
-	if(IsFakeClient(client) && !GetConVarBool(g_hCVBotEarnExpObjective))
+	if(IsFakeClient(client) && !g_hCVBotEarnExpObjective.BoolValue)
 		return;
 	
-	new Float:fTeamRatio = SMRPG_TeamRatio(iTeam == 2 ? 3 : 2);
-	Debug_AddClientExperience(client, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(client))) * GetConVarFloat(g_hCVExpBombExploded) * fTeamRatio), false, "cs_bombexploded");
+	float fTeamRatio = SMRPG_TeamRatio(iTeam == 2 ? 3 : 2);
+	Debug_AddClientExperience(client, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(client))) * g_hCVExpBombExploded.FloatValue * fTeamRatio), false, "cs_bombexploded");
 }
 
-public Event_OnHostageRescued(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnHostageRescued(Event event, const char[] error, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(!client)
 		return;
 	
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	new iTeam = GetClientTeam(client);
+	int iTeam = GetClientTeam(client);
 	if(iTeam <= 1)
 		return;
 	
-	if(IsFakeClient(client) && !GetConVarBool(g_hCVBotEarnExpObjective))
+	if(IsFakeClient(client) && !g_hCVBotEarnExpObjective.BoolValue)
 		return;
 	
-	new Float:fTeamRatio = SMRPG_TeamRatio(iTeam == 2 ? 3 : 2);
-	Debug_AddClientExperience(client, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(client))) * GetConVarFloat(g_hCVExpHostage) * fTeamRatio), false, "cs_hostagerescued");
+	float fTeamRatio = SMRPG_TeamRatio(iTeam == 2 ? 3 : 2);
+	Debug_AddClientExperience(client, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(client))) * g_hCVExpHostage.FloatValue * fTeamRatio), false, "cs_hostagerescued");
 }
 
-public Event_OnVIPEscaped(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnVIPEscaped(Event event, const char[] error, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(!client)
 		return;
 	
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	new iTeam = GetClientTeam(client);
+	int iTeam = GetClientTeam(client);
 	if(iTeam <= 1)
 		return;
 	
-	if(IsFakeClient(client) && !GetConVarBool(g_hCVBotEarnExpObjective))
+	if(IsFakeClient(client) && !g_hCVBotEarnExpObjective.BoolValue)
 		return;
 	
-	new Float:fTeamRatio = SMRPG_TeamRatio(iTeam == 2 ? 3 : 2);
-	Debug_AddClientExperience(client, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(client))) * GetConVarFloat(g_hCVExpVIPEscaped) * fTeamRatio), false, "cs_vipescaped");
+	float fTeamRatio = SMRPG_TeamRatio(iTeam == 2 ? 3 : 2);
+	Debug_AddClientExperience(client, RoundToCeil(float(SMRPG_LevelToExperience(SMRPG_GetClientLevel(client))) * g_hCVExpVIPEscaped.FloatValue * fTeamRatio), false, "cs_vipescaped");
 }
 
-public Action:Timer_ResetKnifeLeveling(Handle:timer, any:userid)
+public Action Timer_ResetKnifeLeveling(Handle timer, any userid)
 {
-	new client = GetClientOfUserId(userid);
+	int client = GetClientOfUserId(userid);
 	if(!client)
 		return Plugin_Stop;
 	
 	//PrintToServer("%N knifeleveling status was reset.", client);
-	g_hKnifeLevelCooldown[client] = INVALID_HANDLE;
+	g_hKnifeLevelCooldown[client] = null;
 	g_bKnifeLeveled[client] = false;
 	return Plugin_Stop;
 }
 
-UpdateMVPLevel(client)
+void UpdateMVPLevel(int client)
 {
-	if(!GetConVarBool(g_hCVShowMVPLevel))
+	if(!g_hCVShowMVPLevel.BoolValue)
 		return;
 	
 	if (IsFakeClient(client) && SMRPG_IgnoreBots())
@@ -489,21 +490,21 @@ UpdateMVPLevel(client)
 
 // This stuff is leftover from balancing the experience on a deathmatch server.
 // Maybe someone finds it useful too when playing with the experience settings, so i'll leave it here.
-Debug_AddClientExperience(client, exp, bool:bHideNotice, const String:sReason[], victim=-1)
+void Debug_AddClientExperience(int client, int exp, bool bHideNotice, const char[] sReason, int victim=-1)
 {
 #if !defined _DEBUG
 	// This is all that's really needed
 	SMRPG_AddClientExperience(client, exp, sReason, bHideNotice, victim, SMRPG_TranslateExperienceReason);
 #else
-	new iOldLevel = SMRPG_GetClientLevel(client);
-	new iOldExperience = SMRPG_GetClientExperience(client);
-	new iOldNeeded = SMRPG_LevelToExperience(iOldLevel);
+	int iOldLevel = SMRPG_GetClientLevel(client);
+	int iOldExperience = SMRPG_GetClientExperience(client);
+	int iOldNeeded = SMRPG_LevelToExperience(iOldLevel);
 	
-	new iOriginalExperience = exp;
-	new bool:bAdded = SMRPG_AddClientExperience(client, exp, sReason, bHideNotice, victim, SMRPG_TranslateExperienceReason);
+	int iOriginalExperience = exp;
+	bool bAdded = SMRPG_AddClientExperience(client, exp, sReason, bHideNotice, victim, SMRPG_TranslateExperienceReason);
 	
-	new iNewLevel = SMRPG_GetClientLevel(client);
-	new String:sAttackerAuth[40], String:sVictimString[256], String:sLevelInc[32], String:sChangedExperience[32];
+	int iNewLevel = SMRPG_GetClientLevel(client);
+	char sAttackerAuth[40], sVictimString[256], sLevelInc[32], sChangedExperience[32];
 	GetClientAuthId(client, AuthId_Engine, sAttackerAuth, sizeof(sAttackerAuth));
 	if(victim > 0)
 		Format(sVictimString, sizeof(sVictimString), " %N (lvl %d)", victim, SMRPG_GetClientLevel(victim));
@@ -521,28 +522,28 @@ Debug_AddClientExperience(client, exp, bool:bHideNotice, const String:sReason[],
 }
 
 #if defined _DEBUG
-stock DebugLog(String:format[], any:...)
+stock void DebugLog(const char[] format, any ...)
 {
-	static String:sLog[8192] = "";
-	static Handle:hFile = INVALID_HANDLE;
-	static iOpenTime = 0;
-	decl String:sBuffer[256];
+	static char sLog[8192] = "";
+	static File hFile = null;
+	static int iOpenTime = 0;
+	char sBuffer[256];
 	SetGlobalTransTarget(LANG_SERVER);
 	VFormat(sBuffer, sizeof(sBuffer), format, 2);
 	
-	decl String:sOldDate[9], String:sCurrentDate[9];
+	char sOldDate[9], sCurrentDate[9];
 	FormatTime(sOldDate, sizeof(sOldDate), "%Y%m%d", iOpenTime);
 	FormatTime(sCurrentDate, sizeof(sCurrentDate), "%Y%m%d");
 	
-	if(hFile == INVALID_HANDLE || !StrEqual(sOldDate, sCurrentDate))
+	if(hFile == null || !StrEqual(sOldDate, sCurrentDate))
 	{
-		decl String:sPath[PLATFORM_MAX_PATH];
+		char sPath[PLATFORM_MAX_PATH];
 		FormatTime(sPath, sizeof(sPath), "%Y_%m_%d");
 		BuildPath(Path_SM, sPath, sizeof(sPath), "data/smrpg_experience_%s.log", sPath);
 		
 		// Basic log rotation
-		if(!StrEqual(sOldDate, sCurrentDate) && hFile != INVALID_HANDLE)
-			CloseHandle(hFile);
+		if(!StrEqual(sOldDate, sCurrentDate) && hFile != null)
+			delete hFile;
 		
 		hFile = OpenFile(sPath, "a");
 		iOpenTime = GetTime();
@@ -551,12 +552,12 @@ stock DebugLog(String:format[], any:...)
 	// Flush the buffer.
 	if((strlen(sLog) + strlen(sBuffer) + 24) >= sizeof(sLog)-1)
 	{
-		if(hFile != INVALID_HANDLE)
-			WriteFileString(hFile, sLog, false);
+		if(hFile != null)
+			hFile.WriteString(sLog, false);
 		sLog[0] = 0;
 	}
 	
-	decl String:sDate[32];
+	char sDate[32];
 	FormatTime(sDate, sizeof(sDate), "%m/%d/%Y - %H:%M:%S: ");
 	StrCat(sLog, sizeof(sLog), sDate);
 	StrCat(sLog, sizeof(sLog), sBuffer);

--- a/scripting/smrpg_effects.sp
+++ b/scripting/smrpg_effects.sp
@@ -3,6 +3,8 @@
 #include <sdktools>
 #include <sdkhooks>
 #include <smlib>
+
+#pragma newdecls required
 #include <smrpg_effects>
 #include <smrpg_sharedmaterials>
 
@@ -11,14 +13,14 @@
 
 #define PLUGIN_VERSION "1.0"
 
-new Handle:g_hCVCreditFireAttacker;
+ConVar g_hCVCreditFireAttacker;
 
 #include "smrpg_effects/rendercolor.sp"
 #include "smrpg_effects/freeze.sp"
 #include "smrpg_effects/ignite.sp"
 #include "smrpg_effects/laggedmovement.sp"
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG > Effect Hub",
 	author = "Peace-Maker",
@@ -27,7 +29,7 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
 	RegPluginLibrary("smrpg_effects");
 	RegisterFreezeNatives();
@@ -38,7 +40,7 @@ public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
 	return APLRes_Success;
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	SMRPG_GC_CheckSharedMaterialsAndSounds();
 	
@@ -53,25 +55,25 @@ public OnPluginStart()
 	AutoExecConfig(true, "plugin.smrpg_effects");
 
 	// Account for late loading
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i))
 			OnClientPutInServer(i);
 	}
 }
 
-public OnMapStart()
+public void OnMapStart()
 {
 	PrecacheFreezeSounds();
 }
 
-public OnClientPutInServer(client)
+public void OnClientPutInServer(int client)
 {
 	SDKHook(client, SDKHook_OnTakeDamage, Hook_OnTakeDamage);
 	ResetRenderColorClient(client);
 }
 
-public OnClientDisconnect(client)
+public void OnClientDisconnect(int client)
 {
 	ResetRenderColorClient(client);
 	ResetFreezeClient(client);
@@ -82,9 +84,9 @@ public OnClientDisconnect(client)
 /**
  * Event callbacks
  */
-public Event_OnPlayerSpawn(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnPlayerSpawn(Event event, const char[] error, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(!client)
 		return;
 
@@ -94,9 +96,9 @@ public Event_OnPlayerSpawn(Handle:event, const String:error[], bool:dontBroadcas
 	ResetLaggedMovementClient(client);
 }
 
-public Event_OnPlayerDeath(Handle:event, const String:error[], bool:dontBroadcast)
+public void Event_OnPlayerDeath(Event event, const char[] error, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(!client)
 		return;
 
@@ -108,10 +110,10 @@ public Event_OnPlayerDeath(Handle:event, const String:error[], bool:dontBroadcas
 /**
  * Hook callbacks
  */
-public Action:Hook_OnTakeDamage(victim, &attacker, &inflictor, &Float:damage, &damagetype, &weapon, Float:damageForce[3], Float:damagePosition[3], damagecustom)
+public Action Hook_OnTakeDamage(int victim, int &attacker, int &inflictor, float &damage, int &damagetype, int &weapon, float damageForce[3], float damagePosition[3], int damagecustom)
 {
-	new Action:iRetFreeze = Freeze_OnTakeDamage(victim, attacker, inflictor, damage);
-	new Action:iRetIgnite = Ignite_OnTakeDamage(victim, attacker, inflictor, damage, damagetype);
+	Action iRetFreeze = Freeze_OnTakeDamage(victim, attacker, inflictor, damage);
+	Action iRetIgnite = Ignite_OnTakeDamage(victim, attacker, inflictor, damage, damagetype);
 	return iRetFreeze > iRetIgnite ? iRetFreeze : iRetIgnite;
 }
 
@@ -120,22 +122,22 @@ public Action:Hook_OnTakeDamage(victim, &attacker, &inflictor, &Float:damage, &d
  */
 // IsValidHandle() is deprecated, let's do a real check then...
 // By Thraaawn
-stock bool:IsValidPlugin(Handle:hPlugin) {
-	if(hPlugin == INVALID_HANDLE)
+stock bool IsValidPlugin(Handle hPlugin) {
+	if(hPlugin == null)
 		return false;
 
-	new Handle:hIterator = GetPluginIterator();
+	Handle hIterator = GetPluginIterator();
 
-	new bool:bPluginExists = false;
+	bool bPluginExists = false;
 	while(MorePlugins(hIterator)) {
-		new Handle:hLoadedPlugin = ReadPlugin(hIterator);
+		Handle hLoadedPlugin = ReadPlugin(hIterator);
 		if(hLoadedPlugin == hPlugin) {
 			bPluginExists = true;
 			break;
 		}
 	}
 
-	CloseHandle(hIterator);
+	delete hIterator;
 
 	return bPluginExists;
 }

--- a/scripting/smrpg_effects/ignite.sp
+++ b/scripting/smrpg_effects/ignite.sp
@@ -119,7 +119,7 @@ public int Native_IgniteClient(Handle plugin, int numParams)
 		attacker = GetNativeCell(5);
 
 	// Server admin doesn't want the attacker to get credit for the fire damage.
-	if (!GetConVarBool(g_hCVCreditFireAttacker))
+	if (!g_hCVCreditFireAttacker.BoolValue)
 		attacker = -1;
 	
 	if (attacker != -1 && (attacker <= 0 || attacker > MaxClients))

--- a/scripting/smrpg_import_thcrpg.sp
+++ b/scripting/smrpg_import_thcrpg.sp
@@ -2,12 +2,13 @@
 #include <sourcemod>
 #include <regex>
 
+#pragma newdecls required
 #define PLUGIN_VERSION "1.0"
 
 // How many players to fetch and import at once.
 #define IMPORT_STEP 100
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG > Import THC RPG database",
 	author = "Peace-Maker",
@@ -16,18 +17,18 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	RegAdminCmd("sm_importrpgdb", Cmd_ImportDatabase, ADMFLAG_ROOT, "Import player level and experience from THC RPG. Usage: sm_importrpgdb [minlevel]");
 }
 
-public Action:Cmd_ImportDatabase(client, args)
+public Action Cmd_ImportDatabase(int client, int args)
 {
 	// Parse the optional argument for minimum level to import.
-	new iMinimumLevel = 1;
+	int iMinimumLevel = 1;
 	if (args >= 1)
 	{
-		new String:sArgs[32];
+		char sArgs[32];
 		GetCmdArgString(sArgs, sizeof(sArgs));
 		StripQuotes(sArgs);
 		
@@ -39,67 +40,67 @@ public Action:Cmd_ImportDatabase(client, args)
 		return Plugin_Handled;
 	}
 	
-	new Handle:hCreditsStart = FindConVar("smrpg_credits_start");
+	ConVar hCreditsStart = FindConVar("smrpg_credits_start");
 	if (!hCreditsStart)
 	{
 		ReplyToCommand(client, "Error finding smrpg_credits_start convar. SM:RPG loaded?");
 		return Plugin_Handled;
 	}
-	new iCreditsStart = GetConVarInt(hCreditsStart);
+	int iCreditsStart = hCreditsStart.IntValue;
 	
-	new Handle:hCreditsInc = FindConVar("smrpg_credits_inc");
+	ConVar hCreditsInc = FindConVar("smrpg_credits_inc");
 	if (!hCreditsInc)
 	{
 		ReplyToCommand(client, "Error finding smrpg_credits_inc convar. SM:RPG loaded?");
 		return Plugin_Handled;
 	}
-	new iCreditsInc = GetConVarInt(hCreditsInc);
+	int iCreditsInc = hCreditsInc.IntValue;
 	
 	// First connect to the smrpg database.
-	new String:sError[256];
-	new Handle:hNewDb = SQL_Connect("smrpg", true, sError, sizeof(sError));
+	char sError[256];
+	Database hNewDb = SQL_Connect("smrpg", true, sError, sizeof(sError));
 	if (!hNewDb)
 	{
 		ReplyToCommand(client, "Error connecting to SM:RPG database: %s", sError);
 		return Plugin_Handled;
 	}
 	
-	SQL_SetCharset(hNewDb, "utf8");
+	hNewDb.SetCharset("utf8");
 	
 	// Make sure it's empty for now.
-	new Handle:hResult = SQL_Query(hNewDb, "SELECT COUNT(*) FROM players");
+	DBResultSet hResult = SQL_Query(hNewDb, "SELECT COUNT(*) FROM players");
 	if (!hResult)
 	{
 		SQL_GetError(hNewDb, sError, sizeof(sError));
 		ReplyToCommand(client, "Error checking state of SM:RPG database: %s", sError);
-		CloseHandle(hNewDb);
+		delete hNewDb;
 		return Plugin_Handled;
 	}
 	
-	if (SQL_FetchRow(hResult))
+	if (hResult.FetchRow())
 	{
 		// smrpg database not empty!
-		new iCount = SQL_FetchInt(hResult, 0);
+		int iCount = hResult.FetchInt(0);
 		if (iCount > 0)
 		{
 			ReplyToCommand(client, "There are already %d player entries in your SM:RPG database. You have to import the levels into an empty database. Please clean the SM:RPG database first and start the server with smrpg_save_data 0.", iCount);
-			CloseHandle(hResult);
-			CloseHandle(hNewDb);
+			delete hResult;
+			delete hNewDb;
 			return Plugin_Handled;
 		}
 	}
-	CloseHandle(hResult);
+	delete hResult;
 	
 	// Connect to the thc_rpg database now.
-	new Handle:hOldDb = SQL_Connect("thc_rpg", true, sError, sizeof(sError));
+	Database hOldDb = SQL_Connect("thc_rpg", true, sError, sizeof(sError));
 	if (!hOldDb)
 	{
 		ReplyToCommand(client, "Error connecting to thc_rpg database: %s", sError);
-		CloseHandle(hNewDb);
+		delete hNewDb;
 		return Plugin_Handled;
 	}
 	
-	SQL_SetCharset(hOldDb, "utf8");
+	hOldDb.SetCharset("utf8");
 	
 	// Get player count.
 	hResult = SQL_Query(hOldDb, "SELECT COUNT(*) FROM thc_rpg WHERE level >= %d", iMinimumLevel);
@@ -107,30 +108,30 @@ public Action:Cmd_ImportDatabase(client, args)
 	{
 		SQL_GetError(hOldDb, sError, sizeof(sError));
 		ReplyToCommand(client, "Error fetching player count from thc_rpg database: %s", sError);
-		CloseHandle(hNewDb);
-		CloseHandle(hOldDb);
+		delete hNewDb;
+		delete hOldDb;
 		return Plugin_Handled;
 	}
 	
-	new iCount;
-	if (SQL_FetchRow(hResult))
-		iCount = SQL_FetchInt(hResult, 0);
-	CloseHandle(hResult);
+	int iCount;
+	if (hResult.FetchRow())
+		iCount = hResult.FetchInt(0);
+	delete hResult;
 	
 	ReplyToCommand(client, "Going to import %d players with at least level %d ...", iCount, iMinimumLevel);
 	
-	new iUserId = client;
+	int iUserId = client;
 	if (client > 0)
 		iUserId = GetClientUserId(client);
 	
-	new String:sAuthId[64], String:sName[128], iXP, iLevel, iCredits;
-	new iAccountId, String:sEscapedName[257];
-	new String:sQuery[1024];
+	char sAuthId[64], sName[128];
+	int iXP, iLevel, iCredits, iAccountId;
+	char sEscapedName[257], sQuery[1024];
 	
-	new iCurrentTime = GetTime();
+	int iCurrentTime = GetTime();
 	
 	// Load old players in chunks, so we don't try to load the whole database into memory.
-	for (new i=0; i<iCount; i+=IMPORT_STEP)
+	for (int i=0; i<iCount; i+=IMPORT_STEP)
 	{
 		// Fetch a chunk of players.
 		// Don't care for credits. we reset them so players can choose from the new upgrades.
@@ -140,21 +141,21 @@ public Action:Cmd_ImportDatabase(client, args)
 		{
 			SQL_GetError(hOldDb, sError, sizeof(sError));
 			ReplyToCommand(client, "Error fetching player list chunk %d from thc_rpg database: %s", i, sError);
-			CloseHandle(hNewDb);
-			CloseHandle(hOldDb);
+			delete hNewDb;
+			delete hOldDb;
 			return Plugin_Handled;
 		}
 		
 		// Run through all players and add them to the smrpg database.
-		while(SQL_MoreRows(hResult))
+		while(hResult.MoreRows)
 		{
-			if (!SQL_FetchRow(hResult))
+			if (!hResult.FetchRow())
 				continue;
 			
-			SQL_FetchString(hResult, 0, sAuthId, sizeof(sAuthId));
-			SQL_FetchString(hResult, 1, sName, sizeof(sName));
-			iXP = SQL_FetchInt(hResult, 2);
-			iLevel = SQL_FetchInt(hResult, 3);
+			hResult.FetchString(0, sAuthId, sizeof(sAuthId));
+			hResult.FetchString(1, sName, sizeof(sName));
+			iXP = hResult.FetchInt(2);
+			iLevel = hResult.FetchInt(3);
 			
 			// Some sanity checks.
 			if (iXP < 0)
@@ -176,7 +177,7 @@ public Action:Cmd_ImportDatabase(client, args)
 				}
 			}
 			
-			SQL_EscapeString(hNewDb, sName, sEscapedName, sizeof(sEscapedName));
+			hNewDb.Escape(sName, sEscapedName, sizeof(sEscapedName));
 			
 			// Give the player the amount of credits he'd have at this level.
 			iCredits = iCreditsStart + iCreditsInc * (iLevel - 1);
@@ -191,24 +192,24 @@ public Action:Cmd_ImportDatabase(client, args)
 				// Bot
 				Format(sQuery, sizeof(sQuery), "INSERT INTO players (name, steamid, level, experience, credits, lastseen) VALUES (\"%s\", NULL, %d, %d, %d, %d)", sEscapedName, iLevel, iXP, iCredits, iCurrentTime);
 			}
-			SQL_TQuery(hNewDb, SQL_PrintError, sQuery, iUserId);
+			hNewDb.Query(SQL_PrintError, sQuery, iUserId);
 		}
 		
 		ReplyToCommand(client, "Imported %d/%d players from thc_rpg database.", i + SQL_GetRowCount(hResult), iCount);
-		CloseHandle(hResult);
+		delete hResult;
 	}
 	
 	LogAction(client, -1, "%L imported %d players from thc_rpg database.", client, iCount);
 	
-	CloseHandle(hOldDb);
-	CloseHandle(hNewDb);
+	delete hOldDb;
+	delete hNewDb;
 	
 	return Plugin_Handled;
 }
 
-public SQL_PrintError(Handle:owner, Handle:hndl, const String:error[], any:userid)
+public void SQL_PrintError(Database owner, DBResultSet results, const char[] error, any userid)
 {
-	new client = userid;
+	int client = userid;
 	if(userid > 0)
 	{
 		client = GetClientOfUserId(userid);
@@ -216,7 +217,7 @@ public SQL_PrintError(Handle:owner, Handle:hndl, const String:error[], any:useri
 			return;
 	}
 	
-	if (!hndl)
+	if (!results)
 	{
 		ReplyToCommand(client, "Error importing player: %s", error);
 	}
@@ -225,36 +226,36 @@ public SQL_PrintError(Handle:owner, Handle:hndl, const String:error[], any:useri
 /**
  * Converts a steamid to the accountid.
  */
-stock GetAccountIdFromSteamId(String:sSteamID[])
+stock int GetAccountIdFromSteamId(char[] sSteamID)
 {
-	static Handle:hSteam2 = INVALID_HANDLE;
-	static Handle:hSteam3 = INVALID_HANDLE;
+	static Regex hSteam2 = null;
+	static Regex hSteam3 = null;
 	
-	if (hSteam2 == INVALID_HANDLE)
-		hSteam2 = CompileRegex("^STEAM_[0-9]:([0-9]):([0-9]+)$");
-	if (hSteam3 == INVALID_HANDLE)
-		hSteam3 = CompileRegex("^\\[U:[0-9]:([0-9]+)\\]$");
+	if (hSteam2 == null)
+		hSteam2 = new Regex("^STEAM_[0-9]:([0-9]):([0-9]+)$");
+	if (hSteam3 == null)
+		hSteam3 = new Regex("^\\[U:[0-9]:([0-9]+)\\]$");
 	
-	new String:sBuffer[64];
+	char sBuffer[64];
 	
 	// Steam2 format?
-	if (hSteam2 != INVALID_HANDLE && MatchRegex(hSteam2, sSteamID) == 3)
+	if (hSteam2 != null && hSteam2.Match(sSteamID) == 3)
 	{
-		if(!GetRegexSubString(hSteam2, 1, sBuffer, sizeof(sBuffer)))
+		if(!hSteam2.GetSubString(1, sBuffer, sizeof(sBuffer)))
 			return -1;
 		
-		new Y = StringToInt(sBuffer);
-		if(!GetRegexSubString(hSteam2, 2, sBuffer, sizeof(sBuffer)))
+		int Y = StringToInt(sBuffer);
+		if(!hSteam2.GetSubString(2, sBuffer, sizeof(sBuffer)))
 			return -1;
 		
-		new Z = StringToInt(sBuffer);
+		int Z = StringToInt(sBuffer);
 		return Z*2 + Y;
 	}
 	
 	// Steam3 format?
-	if (hSteam3 != INVALID_HANDLE && MatchRegex(hSteam3, sSteamID) == 2)
+	if (hSteam3 != null && hSteam3.Match(sSteamID) == 2)
 	{
-		if(!GetRegexSubString(hSteam3, 1, sBuffer, sizeof(sBuffer)))
+		if(!hSteam3.GetSubString(1, sBuffer, sizeof(sBuffer)))
 			return -1;
 		
 		return StringToInt(sBuffer);

--- a/scripting/smrpg_import_thcrpg.sp
+++ b/scripting/smrpg_import_thcrpg.sp
@@ -195,7 +195,7 @@ public Action Cmd_ImportDatabase(int client, int args)
 			hNewDb.Query(SQL_PrintError, sQuery, iUserId);
 		}
 		
-		ReplyToCommand(client, "Imported %d/%d players from thc_rpg database.", i + SQL_GetRowCount(hResult), iCount);
+		ReplyToCommand(client, "Imported %d/%d players from thc_rpg database.", i + hResult.RowCount, iCount);
 		delete hResult;
 	}
 	

--- a/scripting/smrpg_keyhint_info.sp
+++ b/scripting/smrpg_keyhint_info.sp
@@ -9,27 +9,28 @@
 #undef REQUIRE_EXTENSIONS
 #include <clientprefs>
 
+#pragma newdecls required
 #define PLUGIN_VERSION "1.0"
 
 #define SECONDS_EXP_AVG_CALC 60.0
 #define EXP_MEMORY_SIZE 10
 
 // RPG Topmenu
-new Handle:g_hRPGMenu;
+TopMenu g_hRPGMenu;
 
 // Clientprefs
-new bool:g_bClientHidePanel[MAXPLAYERS+1];
-new Handle:g_hCookieHidePanel;
+bool g_bClientHidePanel[MAXPLAYERS+1];
+Handle g_hCookieHidePanel;
 
 // Last experience memory
-new g_iLastExperience[MAXPLAYERS+1];
-new Handle:g_hExperienceMemory[MAXPLAYERS+1];
-new g_iExperienceThisMinute[MAXPLAYERS+1];
-new Float:g_fExperienceAverage[MAXPLAYERS+1];
+int g_iLastExperience[MAXPLAYERS+1];
+ArrayList g_hExperienceMemory[MAXPLAYERS+1];
+int g_iExperienceThisMinute[MAXPLAYERS+1];
+float g_fExperienceAverage[MAXPLAYERS+1];
 
-new bool:g_bIsCSGO;
+bool g_bIsCSGO;
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG > Key Hint Infopanel",
 	author = "Jannik \"Peace-Maker\" Hartung",
@@ -38,14 +39,14 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	LoadTranslations("common.phrases");
 	LoadTranslations("smrpg.phrases");
 	LoadTranslations("smrpg_keyhint_info.phrases");
 	
-	new Handle:hTopMenu;
-	if((hTopMenu = SMRPG_GetTopMenu()) != INVALID_HANDLE)
+	TopMenu hTopMenu;
+	if((hTopMenu = SMRPG_GetTopMenu()) != null)
 		SMRPG_OnRPGMenuReady(hTopMenu);
 	
 	if(LibraryExists("clientprefs"))
@@ -53,14 +54,14 @@ public OnPluginStart()
 	
 	g_bIsCSGO = GetEngineVersion() == Engine_CSGO;
 	
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i))
 			OnClientPutInServer(i);
 	}
 }
 
-public OnLibraryAdded(const String:name[])
+public void OnLibraryAdded(const char[] name)
 {
 	if(StrEqual(name, "clientprefs"))
 	{
@@ -68,27 +69,27 @@ public OnLibraryAdded(const String:name[])
 	}
 }
 
-public OnLibraryRemoved(const String:name[])
+public void OnLibraryRemoved(const char[] name)
 {
 	if(StrEqual(name, "clientprefs"))
 	{
-		g_hCookieHidePanel = INVALID_HANDLE;
+		g_hCookieHidePanel = null;
 	}
 }
 
-public OnClientCookiesCached(client)
+public void OnClientCookiesCached(int client)
 {
-	decl String:sBuffer[4];
+	char sBuffer[4];
 	GetClientCookie(client, g_hCookieHidePanel, sBuffer, sizeof(sBuffer));
 	g_bClientHidePanel[client] = StringToInt(sBuffer)==1;
 }
 
-public OnClientPutInServer(client)
+public void OnClientPutInServer(int client)
 {
-	g_hExperienceMemory[client] = CreateArray();
+	g_hExperienceMemory[client] = new ArrayList();
 }
 
-public OnClientDisconnect(client)
+public void OnClientDisconnect(int client)
 {
 	g_bClientHidePanel[client] = false;
 	g_iLastExperience[client] = 0;
@@ -97,22 +98,25 @@ public OnClientDisconnect(client)
 	g_fExperienceAverage[client] = 0.0;
 }
 
-public OnMapStart()
+public void OnMapStart()
 {
 	CreateTimer(1.0, Timer_ShowInfoPanel, _, TIMER_FLAG_NO_MAPCHANGE|TIMER_REPEAT);
 	CreateTimer(SECONDS_EXP_AVG_CALC, Timer_CalculateEstimatedLevelupTime, _, TIMER_FLAG_NO_MAPCHANGE|TIMER_REPEAT);
 }
 
-public Action:Timer_ShowInfoPanel(Handle:timer)
+public Action Timer_ShowInfoPanel(Handle timer)
 {
 	if(!SMRPG_IsEnabled())
 		return Plugin_Continue;
 	
-	new iTarget, Obs_Mode:iMode, String:sBuffer[512];
-	new iLevel, iExp, iExpForLevel, iExpNeeded, String:sTime[32];
+	int iTarget;
+	Obs_Mode iMode;
+	char sBuffer[512];
+	int iLevel, iExp, iExpForLevel, iExpNeeded;
+	char sTime[32];
 	
-	new iRankCount = SMRPG_GetRankCount();
-	for(new i=1;i<=MaxClients;i++)
+	int iRankCount = SMRPG_GetRankCount();
+	for(int i=1;i<=MaxClients;i++)
 	{
 		// This player doesn't want this info.
 		if(g_bClientHidePanel[i])
@@ -174,7 +178,7 @@ public Action:Timer_ShowInfoPanel(Handle:timer)
 		// No space for that in CS:GO :(
 		if (!g_bIsCSGO)
 		{
-			new iRank = SMRPG_GetClientRank(iTarget);
+			int iRank = SMRPG_GetClientRank(iTarget);
 			if(iRank > 0)
 				Format(sBuffer, sizeof(sBuffer), "%s\n%T", sBuffer, "Rank", i, iRank, iRankCount);
 		}
@@ -209,10 +213,10 @@ public Action:Timer_ShowInfoPanel(Handle:timer)
 	return Plugin_Continue;
 }
 
-public Action:Timer_CalculateEstimatedLevelupTime(Handle:timer)
+public Action Timer_CalculateEstimatedLevelupTime(Handle timer)
 {
-	new iCount, iTotalExp;
-	for(new client=1;client<=MaxClients;client++)
+	int iCount, iTotalExp;
+	for(int client=1;client<=MaxClients;client++)
 	{
 		if(!IsClientInGame(client))
 			continue;
@@ -220,32 +224,32 @@ public Action:Timer_CalculateEstimatedLevelupTime(Handle:timer)
 		iCount = GetArraySize(g_hExperienceMemory[client]);
 		if(iCount < EXP_MEMORY_SIZE)
 		{
-			PushArrayCell(g_hExperienceMemory[client], g_iExperienceThisMinute[client]);
+			g_hExperienceMemory[client].Push(g_iExperienceThisMinute[client]);
 		}
 		// Keep the array at EXP_MEMORY_SIZE size
 		else
 		{
-			ShiftArrayUp(g_hExperienceMemory[client], 0);
-			SetArrayCell(g_hExperienceMemory[client], 0, g_iExperienceThisMinute[client]);
-			RemoveFromArray(g_hExperienceMemory[client], EXP_MEMORY_SIZE);
+			g_hExperienceMemory[client].ShiftUp(0);
+			g_hExperienceMemory[client].Set(0, g_iExperienceThisMinute[client]);
+			g_hExperienceMemory[client].Erase(EXP_MEMORY_SIZE);
 		}
 		
 		// Start counting experience for the next minute.
 		g_iExperienceThisMinute[client] = 0;
 		
 		// Get the average over the past few minutes
-		iCount = GetArraySize(g_hExperienceMemory[client]);
+		iCount = g_hExperienceMemory[client].Length;
 		iTotalExp = 0;
-		for(new i=0;i<iCount;i++)
+		for(int i=0;i<iCount;i++)
 		{
-			iTotalExp += GetArrayCell(g_hExperienceMemory[client], i);
+			iTotalExp += g_hExperienceMemory[client].Get(i);
 		}
 		
 		g_fExperienceAverage[client] = float(iTotalExp)/float(iCount);
 	}
 }
 
-public SMRPG_OnAddExperiencePost(client, const String:reason[], iExperience, other)
+public void SMRPG_OnAddExperiencePost(int client, const char[] reason, int iExperience, int other)
 {
 	g_iLastExperience[client] = iExperience;
 	g_iExperienceThisMinute[client] += iExperience;
@@ -255,7 +259,7 @@ public SMRPG_OnAddExperiencePost(client, const String:reason[], iExperience, oth
  * RPG Topmenu stuff
  */
 
-public SMRPG_OnRPGMenuReady(Handle:topmenu)
+public void SMRPG_OnRPGMenuReady(TopMenu topmenu)
 {
 	// Block us from being called twice!
 	if(g_hRPGMenu == topmenu)
@@ -263,14 +267,14 @@ public SMRPG_OnRPGMenuReady(Handle:topmenu)
 	
 	g_hRPGMenu = topmenu;
 	
-	new TopMenuObject:iTopMenuSettings = FindTopMenuCategory(g_hRPGMenu, RPGMENU_SETTINGS);
+	TopMenuObject iTopMenuSettings = g_hRPGMenu.FindCategory(RPGMENU_SETTINGS);
 	if(iTopMenuSettings != INVALID_TOPMENUOBJECT)
 	{
-		AddToTopMenu(g_hRPGMenu, "rpgkeyhint_showinfo", TopMenuObject_Item, TopMenu_SettingsItemHandler, iTopMenuSettings);
+		g_hRPGMenu.AddItem("rpgkeyhint_showinfo", TopMenu_SettingsItemHandler, iTopMenuSettings);
 	}
 }
 
-public TopMenu_SettingsItemHandler(Handle:topmenu, TopMenuAction:action, TopMenuObject:object_id, param, String:buffer[], maxlength)
+public void TopMenu_SettingsItemHandler(TopMenu topmenu, TopMenuAction action, TopMenuObject object_id, int param, char[] buffer, int maxlength)
 {
 	switch(action)
 	{
@@ -282,14 +286,14 @@ public TopMenu_SettingsItemHandler(Handle:topmenu, TopMenuAction:action, TopMenu
 		{
 			g_bClientHidePanel[param] = !g_bClientHidePanel[param];
 			
-			if(g_hCookieHidePanel != INVALID_HANDLE && AreClientCookiesCached(param))
+			if(g_hCookieHidePanel != null && AreClientCookiesCached(param))
 			{
-				decl String:sBuffer[4];
+				char sBuffer[4];
 				IntToString(g_bClientHidePanel[param], sBuffer, sizeof(sBuffer));
 				SetClientCookie(param, g_hCookieHidePanel, sBuffer);
 			}
 			
-			DisplayTopMenu(g_hRPGMenu, param, TopMenuPosition_LastCategory);
+			topmenu.Display(param, TopMenuPosition_LastCategory);
 			
 			// Hide the panel right away to be responsive!
 			if(g_bClientHidePanel[param] && !g_bIsCSGO)
@@ -299,15 +303,15 @@ public TopMenu_SettingsItemHandler(Handle:topmenu, TopMenuAction:action, TopMenu
 }
 
 // Taken from SourceBans 2's sb_bans :)
-SecondsToString(String:sBuffer[], iLength, iSecs, bool:bTextual = true)
+void SecondsToString(char[] sBuffer, int iLength, int iSecs, bool bTextual = true)
 {
 	if(bTextual)
 	{
-		decl String:sDesc[6][8] = {"mo",              "wk",             "d",          "hr",    "min", "sec"};
-		new  iCount, iDiv[6]    = {60 * 60 * 24 * 30, 60 * 60 * 24 * 7, 60 * 60 * 24, 60 * 60, 60,    1};
+		char sDesc[6][8] = {"mo",              "wk",             "d",          "hr",    "min", "sec"};
+		int  iCount, iDiv[6]    = {60 * 60 * 24 * 30, 60 * 60 * 24 * 7, 60 * 60 * 24, 60 * 60, 60,    1};
 		sBuffer[0]              = '\0';
 		
-		for(new i = 0; i < sizeof(iDiv); i++)
+		for(int i = 0; i < sizeof(iDiv); i++)
 		{
 			if((iCount = iSecs / iDiv[i]) > 0)
 			{
@@ -319,9 +323,9 @@ SecondsToString(String:sBuffer[], iLength, iSecs, bool:bTextual = true)
 	}
 	else
 	{
-		new iHours = iSecs  / 60 / 60;
+		int iHours = iSecs  / 60 / 60;
 		iSecs     -= iHours * 60 * 60;
-		new iMins  = iSecs  / 60;
+		int iMins  = iSecs  / 60;
 		iSecs     %= 60;
 		Format(sBuffer, iLength, "%02i:%02i:%02i", iHours, iMins, iSecs);
 	}

--- a/scripting/upgrades/smrpg_upgrade_armorhelmet_cstrike.sp
+++ b/scripting/upgrades/smrpg_upgrade_armorhelmet_cstrike.sp
@@ -5,14 +5,16 @@
 
 #pragma semicolon 1
 #include <sourcemod>
+
+#pragma newdecls required
 #include <smrpg>
 
 #define UPGRADE_SHORTNAME "armorhelmet"
 #define PLUGIN_VERSION "1.0"
 
-new Handle:g_hCVChance;
+ConVar g_hCVChance;
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG Upgrade > Armor Helmet",
 	author = "Peace-Maker",
@@ -21,9 +23,9 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
-	new EngineVersion:engine = GetEngineVersion();
+	EngineVersion engine = GetEngineVersion();
 	if(engine != Engine_CSS && engine != Engine_CSGO)
 	{
 		Format(error, err_max, "This plugin is for use in Counter-Strike games only. Bad engine version %d.", engine);
@@ -32,24 +34,24 @@ public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
 	return APLRes_Success;
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	LoadTranslations("smrpg_stock_upgrades.phrases");
 	HookEvent("player_spawn", Event_OnPlayerSpawn);
 }
 
-public OnPluginEnd()
+public void OnPluginEnd()
 {
 	if(SMRPG_UpgradeExists(UPGRADE_SHORTNAME))
 		SMRPG_UnregisterUpgradeType(UPGRADE_SHORTNAME);
 }
 
-public OnAllPluginsLoaded()
+public void OnAllPluginsLoaded()
 {
 	OnLibraryAdded("smrpg");
 }
 
-public OnLibraryAdded(const String:name[])
+public void OnLibraryAdded(const char[] name)
 {
 	// Register this upgrade in SM:RPG
 	if(StrEqual(name, "smrpg"))
@@ -65,9 +67,9 @@ public OnLibraryAdded(const String:name[])
 /**
  * Event callbacks
  */
-public Event_OnPlayerSpawn(Handle:event, const String:name[], bool:dontBroadcast)
+public void Event_OnPlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if (!client)
 		return;
 	
@@ -80,7 +82,7 @@ public Event_OnPlayerSpawn(Handle:event, const String:name[], bool:dontBroadcast
 		return;
 	
 	// The upgrade is disabled completely?
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	if(!upgrade[UI_enabled])
 		return;
@@ -90,7 +92,7 @@ public Event_OnPlayerSpawn(Handle:event, const String:name[], bool:dontBroadcast
 		return;
 	
 	// Player didn't buy this upgrade yet.
-	new iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
+	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
 	if(iLevel <= 0)
 		return;
 	
@@ -99,7 +101,7 @@ public Event_OnPlayerSpawn(Handle:event, const String:name[], bool:dontBroadcast
 	if(!SMRPG_RunUpgradeEffect(client, UPGRADE_SHORTNAME))
 		return; // Some other plugin doesn't want this effect to run
 	
-	new Float:fChance = float(iLevel) * GetConVarFloat(g_hCVChance);
+	float fChance = float(iLevel) * g_hCVChance.FloatValue;
 	if (GetURandomFloat() < fChance)
 		SetEntProp(client, Prop_Send, "m_bHasHelmet", 1);
 }
@@ -108,24 +110,24 @@ public Event_OnPlayerSpawn(Handle:event, const String:name[], bool:dontBroadcast
  * SM:RPG Upgrade callbacks
  */
 
-public SMRPG_BuySell(client, UpgradeQueryType:type)
+public void SMRPG_BuySell(int client, UpgradeQueryType type)
 {
 	// Here you can apply your effect directly when the client's upgrade level changes.
 	// E.g. adjust the maximal health of the player immediately when he bought the upgrade.
 	// The client doesn't have to be ingame here!
 }
 
-public bool:SMRPG_ActiveQuery(client)
+public bool SMRPG_ActiveQuery(int client)
 {
 	// If this is a passive effect, it's always active, if the player got at least level 1.
 	// If it's an active effect (like a short speed boost) add a check for the effect as well.
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	return SMRPG_IsEnabled() && upgrade[UI_enabled] && SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME) > 0;
 }
 
 // The core wants to display your upgrade somewhere. Translate it into the clients language!
-public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:type, String:translation[], maxlen)
+public void SMRPG_TranslateUpgrade(int client, const char[] shortname, TranslationType type, char[] translation, int maxlen)
 {
 	// Easy pattern is to use the shortname of your upgrade in the translation file
 	if(type == TranslationType_Name)
@@ -133,7 +135,7 @@ public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:
 	// And "shortname description" as phrase in the translation file for the description.
 	else if(type == TranslationType_Description)
 	{
-		new String:sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
+		char sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
 		StrCat(sDescriptionKey, sizeof(sDescriptionKey), " description");
 		Format(translation, maxlen, "%T", sDescriptionKey, client);
 	}

--- a/scripting/upgrades/smrpg_upgrade_armorregen_cstrike.sp
+++ b/scripting/upgrades/smrpg_upgrade_armorregen_cstrike.sp
@@ -1,7 +1,9 @@
 #pragma semicolon 1
 #include <sourcemod>
-#include <smrpg>
 #include <smlib>
+
+#pragma newdecls required
+#include <smrpg>
 
 #undef REQUIRE_PLUGIN
 #include <smrpg_armorplus>
@@ -10,15 +12,15 @@
 
 #define PLUGIN_VERSION "1.0"
 
-new Handle:g_hAmount;
-new Handle:g_hAmountIncrease;
-new Handle:g_hInterval;
-new Handle:g_hIntervalDecrease;
-new Handle:g_hCVGiveHelmet;
+ConVar g_hCVAmount;
+ConVar g_hCVAmountIncrease;
+ConVar g_hCVInterval;
+ConVar g_hCVIntervalDecrease;
+ConVar g_hCVGiveHelmet;
 
-new Handle:g_hRegenerationTimer[MAXPLAYERS+1];
+Handle g_hRegenerationTimer[MAXPLAYERS+1];
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG Upgrade > Armor regeneration",
 	author = "Jannik \"Peace-Maker\" Hartung",
@@ -27,9 +29,9 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
-	new EngineVersion:engine = GetEngineVersion();
+	EngineVersion engine = GetEngineVersion();
 	if(engine != Engine_CSS && engine != Engine_CSGO)
 	{
 		Format(error, err_max, "This plugin is for use in Counter-Strike games only. Bad engine version %d.", engine);
@@ -38,23 +40,23 @@ public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
 	return APLRes_Success;
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	LoadTranslations("smrpg_stock_upgrades.phrases");
 }
 
-public OnPluginEnd()
+public void OnPluginEnd()
 {
 	if(SMRPG_UpgradeExists(UPGRADE_SHORTNAME))
 		SMRPG_UnregisterUpgradeType(UPGRADE_SHORTNAME);
 }
 
-public OnAllPluginsLoaded()
+public void OnAllPluginsLoaded()
 {
 	OnLibraryAdded("smrpg");
 }
 
-public OnLibraryAdded(const String:name[])
+public void OnLibraryAdded(const char[] name)
 {
 	// Register this upgrade in SM:RPG
 	if(StrEqual(name, "smrpg"))
@@ -62,15 +64,15 @@ public OnLibraryAdded(const String:name[])
 		SMRPG_RegisterUpgradeType("Armor regeneration", UPGRADE_SHORTNAME, "Regenerates armor regularly.", 15, true, 5, 5, 10, _, SMRPG_BuySell, SMRPG_ActiveQuery);
 		SMRPG_SetUpgradeTranslationCallback(UPGRADE_SHORTNAME, SMRPG_TranslateUpgrade);
 		
-		g_hAmount = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_armorregen_amount", "1", "Specify the base amount of armor which is regenerated at the first level.", 0, true, 0.1);
-		g_hAmountIncrease = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_armorregen_amount_inc", "1", "Additional armor to regenerate each interval multiplied by level. (base + inc * (level-1))", 0, true, 0.0);
-		g_hInterval = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_armorregen_interval", "1.0", "Specify the base interval rate at which armor is regenerated in seconds at the first level.", 0, true, 0.1);
-		g_hIntervalDecrease = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_armorregen_interval_dec", "0.0", "How much is the base interval reduced for each level?", 0, true, 0.0);
+		g_hCVAmount = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_armorregen_amount", "1", "Specify the base amount of armor which is regenerated at the first level.", 0, true, 0.1);
+		g_hCVAmountIncrease = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_armorregen_amount_inc", "1", "Additional armor to regenerate each interval multiplied by level. (base + inc * (level-1))", 0, true, 0.0);
+		g_hCVInterval = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_armorregen_interval", "1.0", "Specify the base interval rate at which armor is regenerated in seconds at the first level.", 0, true, 0.1);
+		g_hCVIntervalDecrease = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_armorregen_interval_dec", "0.0", "How much is the base interval reduced for each level?", 0, true, 0.0);
 		g_hCVGiveHelmet = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_armorregen_give_helmet", "1", "Give players helmet after they regenerated to 100% of their armor?", 0, true, 0.0, true, 1.0);
 	}
 }
 
-public OnClientDisconnect(client)
+public void OnClientDisconnect(int client)
 {
 	ClearHandle(g_hRegenerationTimer[client]);
 }
@@ -78,48 +80,48 @@ public OnClientDisconnect(client)
 /**
  * SM:RPG Upgrade callbacks
  */
-public SMRPG_BuySell(client, UpgradeQueryType:type)
+public void SMRPG_BuySell(int client, UpgradeQueryType type)
 {
 	// Change timer interval to correct interval for new level.
 	ClearHandle(g_hRegenerationTimer[client]);
-	new iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
+	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
 	if(iLevel <= 0)
 		return;
 	
-	new Float:fInterval = GetConVarFloat(g_hInterval) - GetConVarFloat(g_hIntervalDecrease) * (iLevel - 1);
+	float fInterval = g_hCVInterval.FloatValue - g_hCVIntervalDecrease.FloatValue * (iLevel - 1);
 	g_hRegenerationTimer[client] = CreateTimer(fInterval, Timer_IncreaseArmor, GetClientUserId(client), TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 }
 
-public bool:SMRPG_ActiveQuery(client)
+public bool SMRPG_ActiveQuery(int client)
 {
 	// This is a passive effect, so it's always active, if the player got at least level 1
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	return SMRPG_IsEnabled() && upgrade[UI_enabled] && SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME) > 0;
 }
 
-public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:type, String:translation[], maxlen)
+public void SMRPG_TranslateUpgrade(int client, const char[] shortname, TranslationType type, char[] translation, int maxlen)
 {
 	if(type == TranslationType_Name)
 		Format(translation, maxlen, "%T", UPGRADE_SHORTNAME, client);
 	else if(type == TranslationType_Description)
 	{
-		new String:sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
+		char sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
 		StrCat(sDescriptionKey, sizeof(sDescriptionKey), " description");
 		Format(translation, maxlen, "%T", sDescriptionKey, client);
 	}
 }
 
-public Action:Timer_IncreaseArmor(Handle:timer, any:userid)
+public Action Timer_IncreaseArmor(Handle timer, any userid)
 {
-	new client = GetClientOfUserId(userid);
+	int client = GetClientOfUserId(userid);
 	if(!client)
 		return Plugin_Stop;
 	
 	if(!SMRPG_IsEnabled())
 		return Plugin_Continue;
 	
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	if(!upgrade[UI_enabled])
 		return Plugin_Continue;
@@ -129,27 +131,27 @@ public Action:Timer_IncreaseArmor(Handle:timer, any:userid)
 		return Plugin_Continue;
 	
 	// Player didn't buy this upgrade yet.
-	new iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
+	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
 	if(iLevel <= 0)
 		return Plugin_Continue;
 	
 	if(!SMRPG_RunUpgradeEffect(client, UPGRADE_SHORTNAME))
 		return Plugin_Continue; // Some other plugin doesn't want this effect to run
 	
-	new iMaxArmor = SMRPG_Armor_GetClientMaxArmor(client);
-	new iCurrentArmor = GetClientArmor(client);
+	int iMaxArmor = SMRPG_Armor_GetClientMaxArmor(client);
+	int iCurrentArmor = GetClientArmor(client);
 	
 	// He already is regenerated completely.
 	if(iCurrentArmor >= iMaxArmor)
 	{
 		// Give him an helmet now.
-		if (GetConVarBool(g_hCVGiveHelmet) && !GetEntProp(client, Prop_Send, "m_bHasHelmet"))
+		if (g_hCVGiveHelmet.BoolValue && !GetEntProp(client, Prop_Send, "m_bHasHelmet"))
 			SetEntProp(client, Prop_Send, "m_bHasHelmet", 1);
 		return Plugin_Continue;
 	}
 	
-	new iIncrease = GetConVarInt(g_hAmount) + GetConVarInt(g_hAmountIncrease) * (iLevel - 1);
-	new iNewArmor = iCurrentArmor + iIncrease;
+	int iIncrease = g_hCVAmount.IntValue + g_hCVAmountIncrease.IntValue * (iLevel - 1);
+	int iNewArmor = iCurrentArmor + iIncrease;
 	if(iNewArmor > iMaxArmor)
 		iNewArmor = iMaxArmor;
 	SetEntProp(client, Prop_Send, "m_ArmorValue", iNewArmor);

--- a/scripting/upgrades/smrpg_upgrade_bouncybullets.sp
+++ b/scripting/upgrades/smrpg_upgrade_bouncybullets.sp
@@ -7,6 +7,8 @@
 #include <sourcemod>
 #include <sdktools>
 #include <sdkhooks>
+
+#pragma newdecls required
 #include <smrpg>
 #include <smrpg_effects>
 
@@ -14,10 +16,10 @@
 #define UPGRADE_SHORTNAME "bouncybullets"
 #define PLUGIN_VERSION "1.0"
 
-new Handle:g_hCVForce;
-new Handle:g_hCVIgnoreWeapons;
+ConVar g_hCVForce;
+ConVar g_hCVIgnoreWeapons;
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG Upgrade > Bouncy Bullets",
 	author = "Peace-Maker",
@@ -26,30 +28,30 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	LoadTranslations("smrpg_stock_upgrades.phrases");
 	
 	// Account for late loading
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i))
 			OnClientPutInServer(i);
 	}
 }
 
-public OnPluginEnd()
+public void OnPluginEnd()
 {
 	if(SMRPG_UpgradeExists(UPGRADE_SHORTNAME))
 		SMRPG_UnregisterUpgradeType(UPGRADE_SHORTNAME);
 }
 
-public OnAllPluginsLoaded()
+public void OnAllPluginsLoaded()
 {
 	OnLibraryAdded("smrpg");
 }
 
-public OnLibraryAdded(const String:name[])
+public void OnLibraryAdded(const char[] name)
 {
 	// Register this upgrade in SM:RPG
 	if(StrEqual(name, "smrpg"))
@@ -66,7 +68,7 @@ public OnLibraryAdded(const String:name[])
 	}
 }
 
-public OnClientPutInServer(client)
+public void OnClientPutInServer(int client)
 {
 	SDKHook(client, SDKHook_OnTakeDamagePost, Hook_OnTakeDamagePost);
 }
@@ -75,24 +77,24 @@ public OnClientPutInServer(client)
  * SM:RPG Upgrade callbacks
  */
 
-public SMRPG_BuySell(client, UpgradeQueryType:type)
+public void SMRPG_BuySell(int client, UpgradeQueryType type)
 {
 	// Here you can apply your effect directly when the client's upgrade level changes.
 	// E.g. adjust the maximal health of the player immediately when he bought the upgrade.
 	// The client doesn't have to be ingame here!
 }
 
-public bool:SMRPG_ActiveQuery(client)
+public bool SMRPG_ActiveQuery(int client)
 {
 	// If this is a passive effect, it's always active, if the player got at least level 1.
 	// If it's an active effect (like a short speed boost) add a check for the effect as well.
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	return SMRPG_IsEnabled() && upgrade[UI_enabled] && SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME) > 0;
 }
 
 // The core wants to display your upgrade somewhere. Translate it into the clients language!
-public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:type, String:translation[], maxlen)
+public void SMRPG_TranslateUpgrade(int client, const char[] shortname, TranslationType type, char[] translation, int maxlen)
 {
 	// Easy pattern is to use the shortname of your upgrade in the translation file
 	if(type == TranslationType_Name)
@@ -100,7 +102,7 @@ public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:
 	// And "shortname description" as phrase in the translation file for the description.
 	else if(type == TranslationType_Description)
 	{
-		new String:sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
+		char sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
 		StrCat(sDescriptionKey, sizeof(sDescriptionKey), " description");
 		Format(translation, maxlen, "%T", sDescriptionKey, client);
 	}
@@ -109,25 +111,25 @@ public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:
 /**
  * Event callbacks
  */
-public Hook_OnTakeDamagePost(victim, attacker, inflictor, Float:damage, damagetype, weapon, const Float:damageForce[3], const Float:damagePosition[3])
+public void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage, int damagetype, int weapon, const float damageForce[3], const float damagePosition[3])
 {
 	if(attacker <= 0 || attacker > MaxClients || victim <= 0 || victim > MaxClients)
 		return;
 
 	// Check whether this weapon shouldn't push the victim.
-	new String:sIgnoreWeapons[512];
-	GetConVarString(g_hCVIgnoreWeapons, sIgnoreWeapons, sizeof(sIgnoreWeapons));
+	char sIgnoreWeapons[512];
+	g_hCVIgnoreWeapons.GetString(sIgnoreWeapons, sizeof(sIgnoreWeapons));
 	
-	new iWeapon = inflictor;
+	int iWeapon = inflictor;
 	if(inflictor > 0 && inflictor <= MaxClients)
 		iWeapon = GetEntPropEnt(inflictor, Prop_Send, "m_hActiveWeapon");
 	
 	if (iWeapon > 0 && IsValidEntity(iWeapon))
 	{
-		new String:sWeapon[64];
+		char sWeapon[64];
 		GetEntityClassname(iWeapon, sWeapon, sizeof(sWeapon));
 		// Skip "weapon_" prefix.
-		new iPos = StrContains(sWeapon, "weapon_", false);
+		int iPos = StrContains(sWeapon, "weapon_", false);
 		if (iPos != -1)
 			iPos += 7;
 		else
@@ -143,7 +145,7 @@ public Hook_OnTakeDamagePost(victim, attacker, inflictor, Float:damage, damagety
 		return;
 	
 	// The upgrade is disabled completely?
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	if(!upgrade[UI_enabled])
 		return;
@@ -157,7 +159,7 @@ public Hook_OnTakeDamagePost(victim, attacker, inflictor, Float:damage, damagety
 		return;
 	
 	// Player didn't buy this upgrade yet.
-	new iLevel = SMRPG_GetClientUpgradeLevel(attacker, UPGRADE_SHORTNAME);
+	int iLevel = SMRPG_GetClientUpgradeLevel(attacker, UPGRADE_SHORTNAME);
 	if(iLevel <= 0)
 		return;
 	
@@ -171,13 +173,13 @@ public Hook_OnTakeDamagePost(victim, attacker, inflictor, Float:damage, damagety
 		return;
 	
 	// Push victim away from attacker's position.
-	new Float:fVictimOrigin[3], Float:fAttackerOrigin[3], Float:fDirection[3];
+	float fVictimOrigin[3], fAttackerOrigin[3], fDirection[3];
 	GetClientEyePosition(victim, fVictimOrigin);
 	GetClientEyePosition(attacker, fAttackerOrigin);
 	MakeVectorFromPoints(fAttackerOrigin, fVictimOrigin, fDirection);
 	NormalizeVector(fDirection, fDirection);
 	
-	new Float:fForce = GetConVarFloat(g_hCVForce) * iLevel;
+	float fForce = g_hCVForce.FloatValue * iLevel;
 	ScaleVector(fDirection, fForce);
 	TeleportEntity(victim, NULL_VECTOR, NULL_VECTOR, fDirection);
 }

--- a/scripting/upgrades/smrpg_upgrade_denial.sp
+++ b/scripting/upgrades/smrpg_upgrade_denial.sp
@@ -8,15 +8,15 @@
 #define UPGRADE_SHORTNAME "denial"
 #define PLUGIN_VERSION "1.0"
 
-new Handle:g_hCVDenialRestrict;
+ConVar g_hCVDenialRestrict;
 
-new bool:g_bDenialPlayerWasDead[MAXPLAYERS+1];
-new Handle:g_hDenialStripTimer[MAXPLAYERS+1] = {INVALID_HANDLE,...};
+bool g_bDenialPlayerWasDead[MAXPLAYERS+1];
+Handle g_hDenialStripTimer[MAXPLAYERS+1] = {null,...};
 
-new String:g_sDenialPrimary[MAXPLAYERS+1][64];
-new String:g_sDenialSecondary[MAXPLAYERS+1][64];
+char g_sDenialPrimary[MAXPLAYERS+1][64];
+char g_sDenialSecondary[MAXPLAYERS+1][64];
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG Upgrade > Denial",
 	author = "Jannik \"Peace-Maker\" Hartung",
@@ -25,7 +25,7 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	HookEvent("player_spawn", Event_OnPlayerSpawn);
 	HookEvent("player_death", Event_OnPlayerDeath);
@@ -34,25 +34,25 @@ public OnPluginStart()
 	LoadTranslations("smrpg_stock_upgrades.phrases");
 	
 	// Account for late loading
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i))
 			OnClientPutInServer(i);
 	}
 }
 
-public OnPluginEnd()
+public void OnPluginEnd()
 {
 	if(SMRPG_UpgradeExists(UPGRADE_SHORTNAME))
 		SMRPG_UnregisterUpgradeType(UPGRADE_SHORTNAME);
 }
 
-public OnAllPluginsLoaded()
+public void OnAllPluginsLoaded()
 {
 	OnLibraryAdded("smrpg");
 }
 
-public OnLibraryAdded(const String:name[])
+public void OnLibraryAdded(const char[] name)
 {
 	// Register this upgrade in SM:RPG
 	if(StrEqual(name, "smrpg"))
@@ -65,12 +65,12 @@ public OnLibraryAdded(const String:name[])
 	}
 }
 
-public OnClientPutInServer(client)
+public void OnClientPutInServer(int client)
 {
 	SDKHook(client, SDKHook_WeaponEquipPost, Hook_WeaponEquipPost);
 }
 
-public OnClientDisconnect(client)
+public void OnClientDisconnect(int client)
 {
 	Denial_ResetClient(client);
 }
@@ -78,13 +78,13 @@ public OnClientDisconnect(client)
 /**
  * Event callbacks
  */
-public Event_OnPlayerSpawn(Handle:event, const String:name[], bool:dontBroadcast)
+public void Event_OnPlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(!client)
 		return;
 	
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	
 	/* Reset player Denial data while Denial is disabled */
@@ -112,13 +112,13 @@ public Event_OnPlayerSpawn(Handle:event, const String:name[], bool:dontBroadcast
 	g_hDenialStripTimer[client] = CreateTimer(0.1, Timer_StripPlayer, GetClientUserId(client), TIMER_FLAG_NO_MAPCHANGE);
 }
 
-public Event_OnPlayerDeath(Handle:event, const String:name[], bool:dontBroadcast)
+public void Event_OnPlayerDeath(Event event, const char[] name, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(!client)
 		return;
 	
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	
 	/* Reset player Denial data while Denial is disabled */
@@ -131,9 +131,9 @@ public Event_OnPlayerDeath(Handle:event, const String:name[], bool:dontBroadcast
 	g_bDenialPlayerWasDead[client] = true;
 }
 
-public Event_OnPlayerTeam(Handle:event, const String:name[], bool:dontBroadcast)
+public void Event_OnPlayerTeam(Event event, const char[] name, bool dontBroadcast)
 {
-	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+	int client = GetClientOfUserId(event.GetInt("userid"));
 	if(!client)
 		return;
 	
@@ -143,34 +143,34 @@ public Event_OnPlayerTeam(Handle:event, const String:name[], bool:dontBroadcast)
 /**
  * SM:RPG Upgrade callbacks
  */
-public SMRPG_BuySell(client, UpgradeQueryType:type)
+public void SMRPG_BuySell(int client, UpgradeQueryType type)
 {
 	
 }
 
-public bool:SMRPG_ActiveQuery(client)
+public bool SMRPG_ActiveQuery(int client)
 {
 	// This is a passive effect, so it's always active, if the player got at least level 1
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	return SMRPG_IsEnabled() && upgrade[UI_enabled] && SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME) > 0;
 }
 
 // Some plugin wants this effect to end?
-public SMRPG_ResetEffect(client)
+public void SMRPG_ResetEffect(int client)
 {
 	g_sDenialPrimary[client][0] = '\0';
 	g_sDenialSecondary[client][0] = '\0';
 	ClearHandle(g_hDenialStripTimer[client]);
 }
 
-public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:type, String:translation[], maxlen)
+public void SMRPG_TranslateUpgrade(int client, const char[] shortname, TranslationType type, char[] translation, int maxlen)
 {
 	if(type == TranslationType_Name)
 		Format(translation, maxlen, "%T", UPGRADE_SHORTNAME, client);
 	else if(type == TranslationType_Description)
 	{
-		new String:sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
+		char sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
 		StrCat(sDescriptionKey, sizeof(sDescriptionKey), " description");
 		Format(translation, maxlen, "%T", sDescriptionKey, client);
 	}
@@ -179,9 +179,9 @@ public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:
 /**
  * SDKHook callbacks
  */
-public Action:Hook_WeaponEquipPost(client, weapon)
+public Action Hook_WeaponEquipPost(int client, int weapon)
 {
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	
 	/* Reset player Denial data while Denial is disabled */
@@ -209,15 +209,15 @@ public Action:Hook_WeaponEquipPost(client, weapon)
 /**
  * Timer callbacks
  */
-public Action:Timer_StripPlayer(Handle:timer, any:userid)
+public Action Timer_StripPlayer(Handle timer, any userid)
 {
-	new client = GetClientOfUserId(userid);
+	int client = GetClientOfUserId(userid);
 	if(!client)
 		return Plugin_Stop;
 	
-	g_hDenialStripTimer[client] = INVALID_HANDLE;
+	g_hDenialStripTimer[client] = null;
 	
-	new iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
+	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
 	if(iLevel <= 0)
 		return Plugin_Stop;
 	
@@ -226,8 +226,8 @@ public Action:Timer_StripPlayer(Handle:timer, any:userid)
 	{
 		if(StrContains(g_sDenialSecondary[client],"weapon_") != -1 && !Denial_IsWeaponRestricted(g_sDenialSecondary[client]))
 		{
-			decl String:sOldWeapon[64];
-			new iCurrentWeapon = GetPlayerWeaponSlot(client, 1);
+			char sOldWeapon[64];
+			int iCurrentWeapon = GetPlayerWeaponSlot(client, 1);
 			// Remove his current weapon
 			if(iCurrentWeapon != INVALID_ENT_REFERENCE)
 			{
@@ -248,8 +248,8 @@ public Action:Timer_StripPlayer(Handle:timer, any:userid)
 	{
 		if(StrContains(g_sDenialPrimary[client],"weapon_") != -1 && !Denial_IsWeaponRestricted(g_sDenialPrimary[client]))
 		{
-			decl String:sOldWeapon[64];
-			new iCurrentWeapon = GetPlayerWeaponSlot(client, 0);
+			char sOldWeapon[64];
+			int iCurrentWeapon = GetPlayerWeaponSlot(client, 0);
 			// Remove his current weapon
 			if(iCurrentWeapon != INVALID_ENT_REFERENCE)
 			{
@@ -274,16 +274,16 @@ public Action:Timer_StripPlayer(Handle:timer, any:userid)
 /**
  * Helper functions
  */
-Denial_ResetClient(client)
+void Denial_ResetClient(int client)
 {
 	g_bDenialPlayerWasDead[client] = false;
 	SMRPG_ResetEffect(client);
 }
 
-bool:Denial_IsWeaponRestricted(String:sWeapon[])
+bool Denial_IsWeaponRestricted(const char[] sWeapon)
 {
-	decl String:sRestrictedWeapons[1024];
-	GetConVarString(g_hCVDenialRestrict, sRestrictedWeapons, sizeof(sRestrictedWeapons));
+	char sRestrictedWeapons[1024];
+	g_hCVDenialRestrict.GetString(sRestrictedWeapons, sizeof(sRestrictedWeapons));
 	
 	new iPos = StrContains(sWeapon, "weapon_");
 	if(iPos != -1)
@@ -296,13 +296,13 @@ bool:Denial_IsWeaponRestricted(String:sWeapon[])
 	return false;
 }
 
-bool:GetRealWeaponClassname(entity, String:sClassname[], maxlen)
+bool GetRealWeaponClassname(int entity, char[] sClassname, int maxlen)
 {
 	// Replace the weapon classname with the correct one for special weapons in CS:GO.
 	if (GetEngineVersion() == Engine_CSGO)
 	{
-		new iItemDefinitionIndex = GetEntProp(entity, Prop_Send, "m_iItemDefinitionIndex");
-		new String:sWeapon[32];
+		int iItemDefinitionIndex = GetEntProp(entity, Prop_Send, "m_iItemDefinitionIndex");
+		char sWeapon[32];
 		switch(iItemDefinitionIndex)
 		{
 			case 60:

--- a/scripting/upgrades/smrpg_upgrade_denial.sp
+++ b/scripting/upgrades/smrpg_upgrade_denial.sp
@@ -2,8 +2,10 @@
 #include <sourcemod>
 #include <sdktools>
 #include <sdkhooks>
-#include <smrpg>
 #include <smlib>
+
+#pragma newdecls required
+#include <smrpg>
 
 #define UPGRADE_SHORTNAME "denial"
 #define PLUGIN_VERSION "1.0"
@@ -285,7 +287,7 @@ bool Denial_IsWeaponRestricted(const char[] sWeapon)
 	char sRestrictedWeapons[1024];
 	g_hCVDenialRestrict.GetString(sRestrictedWeapons, sizeof(sRestrictedWeapons));
 	
-	new iPos = StrContains(sWeapon, "weapon_");
+	int iPos = StrContains(sWeapon, "weapon_");
 	if(iPos != -1)
 		iPos += 7; // skip "weapon_" too.
 	else

--- a/scripting/upgrades/smrpg_upgrade_example.sp
+++ b/scripting/upgrades/smrpg_upgrade_example.sp
@@ -7,15 +7,17 @@
 
 #pragma semicolon 1
 #include <sourcemod>
+
+#pragma newdecls required
 #include <smrpg>
 
 // Change the upgrade's shortname to a descriptive abbrevation
 #define UPGRADE_SHORTNAME "example"
 #define PLUGIN_VERSION "1.0"
 
-new Handle:g_hCVMyConvar;
+ConVar g_hCVMyConvar;
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG Upgrade > Example",
 	author = "You",
@@ -24,23 +26,23 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	LoadTranslations("smrpg_example_upgrade.phrases");
 }
 
-public OnPluginEnd()
+public void OnPluginEnd()
 {
 	if(SMRPG_UpgradeExists(UPGRADE_SHORTNAME))
 		SMRPG_UnregisterUpgradeType(UPGRADE_SHORTNAME);
 }
 
-public OnAllPluginsLoaded()
+public void OnAllPluginsLoaded()
 {
 	OnLibraryAdded("smrpg");
 }
 
-public OnLibraryAdded(const String:name[])
+public void OnLibraryAdded(const char[] name)
 {
 	// Register this upgrade in SM:RPG
 	if(StrEqual(name, "smrpg"))
@@ -67,7 +69,7 @@ public OnLibraryAdded(const String:name[])
 	}
 }
 
-public OnClientDisconnect(client)
+public void OnClientDisconnect(int client)
 {
 	// Don't forget to reset your effect when the client leaves ;)
 	SMRPG_ResetEffect(client);
@@ -77,31 +79,31 @@ public OnClientDisconnect(client)
  * SM:RPG Upgrade callbacks
  */
 
-public SMRPG_BuySell(client, UpgradeQueryType:type)
+public void SMRPG_BuySell(int client, UpgradeQueryType type)
 {
 	// Here you can apply your effect directly when the client's upgrade level changes.
 	// E.g. adjust the maximal health of the player immediately when he bought the upgrade.
 	// The client doesn't have to be ingame here!
 }
 
-public bool:SMRPG_ActiveQuery(client)
+public bool SMRPG_ActiveQuery(int client)
 {
 	// If this is a passive effect, it's always active, if the player got at least level 1.
 	// If it's an active effect (like a short speed boost) add a check for the effect as well.
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	return SMRPG_IsEnabled() && upgrade[UI_enabled] && SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME) > 0;
 }
 
 // Some plugin wants this effect to end?
-public SMRPG_ResetEffect(client)
+public void SMRPG_ResetEffect(int client)
 {
 	// Stop your temporary effects here.
 }
 
 
 // The core wants to display your upgrade somewhere. Translate it into the clients language!
-public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:type, String:translation[], maxlen)
+public void SMRPG_TranslateUpgrade(int client, const char[] shortname, TranslationType type, char[] translation, int maxlen)
 {
 	// Easy pattern is to use the shortname of your upgrade in the translation file
 	if(type == TranslationType_Name)
@@ -109,7 +111,7 @@ public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:
 	// And "shortname description" as phrase in the translation file for the description.
 	else if(type == TranslationType_Description)
 	{
-		new String:sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
+		char sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
 		StrCat(sDescriptionKey, sizeof(sDescriptionKey), " description");
 		Format(translation, maxlen, "%T", sDescriptionKey, client);
 	}
@@ -117,7 +119,7 @@ public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:
 
 // Optionally block some other conflicting effect, if i'm currently active.
 /*
-public Action:SMRPG_OnUpgradeEffect(target, const String:shortname[], issuer)
+public Action SMRPG_OnUpgradeEffect(int target, const char[] shortname, int issuer)
 {
 	if(SMRPG_IsUpgradeActiveOnClient(target, UPGRADE_SHORTNAME) && StrEqual(shortname, "other_conflicting_effect"))
 		return Plugin_Handled;
@@ -126,14 +128,14 @@ public Action:SMRPG_OnUpgradeEffect(target, const String:shortname[], issuer)
 */
 
 // This holds the basic checks you should run before applying your effect.
-ApplyMyUpgradeEffect(client)
+void ApplyMyUpgradeEffect(int client)
 {
 	// SM:RPG is disabled?
 	if(!SMRPG_IsEnabled())
 		return;
 	
 	// The upgrade is disabled completely?
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	if(!upgrade[UI_enabled])
 		return;
@@ -143,7 +145,7 @@ ApplyMyUpgradeEffect(client)
 		return;
 	
 	// Player didn't buy this upgrade yet.
-	new iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
+	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
 	if(iLevel <= 0)
 		return;
 	

--- a/scripting/upgrades/smrpg_upgrade_fastreload.css.sp
+++ b/scripting/upgrades/smrpg_upgrade_fastreload.css.sp
@@ -8,19 +8,21 @@
 #include <sourcemod>
 #include <sdktools>
 #include <sdkhooks>
-#include <smrpg>
 #include <smlib>
+
+#pragma newdecls required
+#include <smrpg>
 
 // Change the upgrade's shortname to a descriptive abbrevation
 // No spaces allowed here. This is going to be used as a sql table column field name!
 #define UPGRADE_SHORTNAME "fastreload"
 #define PLUGIN_VERSION "1.0"
 
-new bool:g_bLateLoaded;
+bool g_bLateLoaded;
 
-new Handle:g_hCVSpeedInc;
+ConVar g_hCVSpeedInc;
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG Upgrade > Fast Reload",
 	author = "Peace-Maker",
@@ -29,7 +31,7 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
+public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
 	g_bLateLoaded = late;
 	
@@ -41,15 +43,15 @@ public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
 	return APLRes_Success;
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	LoadTranslations("smrpg_stock_upgrades.phrases");
 	
 	if(g_bLateLoaded)
 	{
-		new iEntities = GetMaxEntities();
-		decl String:sClassname[64];
-		for(new i=MaxClients+1;i<=iEntities;i++)
+		int iEntities = GetMaxEntities();
+		char sClassname[64];
+		for(int i=MaxClients+1;i<=iEntities;i++)
 		{
 			if(IsValidEntity(i) && GetEntityClassname(i, sClassname, sizeof(sClassname)) && (StrEqual(sClassname, "weapon_m3") || StrEqual(sClassname, "weapon_xm1014")))
 			{
@@ -58,18 +60,18 @@ public OnPluginStart()
 		}
 	}
 }
-public OnPluginEnd()
+public void OnPluginEnd()
 {
 	if(SMRPG_UpgradeExists(UPGRADE_SHORTNAME))
 		SMRPG_UnregisterUpgradeType(UPGRADE_SHORTNAME);
 }
 
-public OnAllPluginsLoaded()
+public void OnAllPluginsLoaded()
 {
 	OnLibraryAdded("smrpg");
 }
 
-public OnLibraryAdded(const String:name[])
+public void OnLibraryAdded(const char[] name)
 {
 	// Register this upgrade in SM:RPG
 	if(StrEqual(name, "smrpg"))
@@ -82,7 +84,7 @@ public OnLibraryAdded(const String:name[])
 	}
 }
 
-public OnEntityCreated(entity, const String:classname[])
+public void OnEntityCreated(int entity, const char[] classname)
 {
 	if(StrEqual(classname, "weapon_m3") || StrEqual(classname, "weapon_xm1014"))
 		SDKHook(entity, SDKHook_ReloadPost, Hook_OnReloadPost);
@@ -92,25 +94,25 @@ public OnEntityCreated(entity, const String:classname[])
  * SM:RPG Upgrade callbacks
  */
 
-public SMRPG_BuySell(client, UpgradeQueryType:type)
+public void SMRPG_BuySell(int client, UpgradeQueryType type)
 {
 	// Here you can apply your effect directly when the client's upgrade level changes.
 	// E.g. adjust the maximal health of the player immediately when he bought the upgrade.
 	// The client doesn't have to be ingame here!
 }
 
-public bool:SMRPG_ActiveQuery(client)
+public bool SMRPG_ActiveQuery(int client)
 {
 	// If this is a passive effect, it's always active, if the player got at least level 1.
 	// If it's an active effect (like a short speed boost) add a check for the effect as well.
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	return SMRPG_IsEnabled() && upgrade[UI_enabled] && SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME) > 0;
 }
 
 
 // The core wants to display your upgrade somewhere. Translate it into the clients language!
-public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:type, String:translation[], maxlen)
+public void SMRPG_TranslateUpgrade(int client, const char[] shortname, TranslationType type, char[] translation, int maxlen)
 {
 	// Easy pattern is to use the shortname of your upgrade in the translation file
 	if(type == TranslationType_Name)
@@ -118,21 +120,21 @@ public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:
 	// And "shortname description" as phrase in the translation file for the description.
 	else if(type == TranslationType_Description)
 	{
-		new String:sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
+		char sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
 		StrCat(sDescriptionKey, sizeof(sDescriptionKey), " description");
 		Format(translation, maxlen, "%T", sDescriptionKey, client);
 	}
 }
 
 // This holds the basic checks you should run before applying your effect.
-IncreaseReloadSpeed(client)
+void IncreaseReloadSpeed(int client)
 {
 	// SM:RPG is disabled?
 	if(!SMRPG_IsEnabled())
 		return;
 	
 	// The upgrade is disabled completely?
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	if(!upgrade[UI_enabled])
 		return;
@@ -142,7 +144,7 @@ IncreaseReloadSpeed(client)
 		return;
 	
 	// Player didn't buy this upgrade yet.
-	new iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
+	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
 	if(iLevel <= 0)
 		return;
 	
@@ -152,8 +154,8 @@ IncreaseReloadSpeed(client)
 		return; // Some other plugin doesn't want this effect to run
 	
 	
-	new String:sWeapon[64];
-	new iWeapon = Client_GetActiveWeaponName(client, sWeapon, sizeof(sWeapon));
+	char sWeapon[64];
+	int iWeapon = Client_GetActiveWeaponName(client, sWeapon, sizeof(sWeapon));
 	
 	//PrintToChatAll("%N is reloading his weapon %d %s.", client, iWeapon, sWeapon);
 	
@@ -161,10 +163,10 @@ IncreaseReloadSpeed(client)
 		return;
 	
 	// No shotgun?
-	new bool:bIsShotgun;
+	bool bIsShotgun;
 	if(StrEqual(sWeapon, "weapon_m3") || StrEqual(sWeapon, "weapon_xm1014"))
 	{
-		new iReloadState = GetEntProp(iWeapon, Prop_Send, "m_reloadState");
+		int iReloadState = GetEntProp(iWeapon, Prop_Send, "m_reloadState");
 		// The shotgun isn't really reloading. (full or no ammo left)
 		if(iReloadState == 0)
 			return;
@@ -172,36 +174,36 @@ IncreaseReloadSpeed(client)
 		bIsShotgun = true;
 	}
 	
-	new Float:fNextAttack = GetEntPropFloat(iWeapon, Prop_Send, "m_flNextPrimaryAttack");
-	new Float:fGameTime = GetGameTime();
+	float fNextAttack = GetEntPropFloat(iWeapon, Prop_Send, "m_flNextPrimaryAttack");
+	float fGameTime = GetGameTime();
 	
 	//PrintToChatAll("gametime %f, weapon nextattack %f, player nextattack %f, weapon idletime %f", fGameTime, fNextAttack, GetEntPropFloat(client, Prop_Send, "m_flNextAttack"), GetEntPropFloat(iWeapon, Prop_Send, "m_flTimeWeaponIdle"));
 	
-	new Float:fReloadIncrease = 1.0 / (1.0 + float(iLevel) * GetConVarFloat(g_hCVSpeedInc));
+	float fReloadIncrease = 1.0 / (1.0 + float(iLevel) * g_hCVSpeedInc.FloatValue);
 	
 	// Change the playback rate of the weapon to see it reload faster visually
 	SetEntPropFloat(iWeapon, Prop_Send, "m_flPlaybackRate", 1.0 / fReloadIncrease);
 	
-	new iViewModel = GetEntPropEnt(client, Prop_Send, "m_hViewModel");
+	int iViewModel = GetEntPropEnt(client, Prop_Send, "m_hViewModel");
 	if(iViewModel != INVALID_ENT_REFERENCE)
 		SetEntPropFloat(iViewModel, Prop_Send, "m_flPlaybackRate", 1.0 / fReloadIncrease);
 	
-	new Float:fNextAttackNew = (fNextAttack - fGameTime) * fReloadIncrease;
+	float fNextAttackNew = (fNextAttack - fGameTime) * fReloadIncrease;
 	
 	if(bIsShotgun)
 	{
-		new Handle:hData;
+		DataPack hData;
 		CreateDataTimer(0.01, Timer_CheckShotgunEnd, hData, TIMER_FLAG_NO_MAPCHANGE|TIMER_REPEAT);
-		WritePackCell(hData, EntIndexToEntRef(iWeapon));
-		WritePackCell(hData, GetClientUserId(client));
+		hData.WriteCell(EntIndexToEntRef(iWeapon));
+		hData.WriteCell(GetClientUserId(client));
 	}
 	else
 	{
 		// Reset the playback rate after the gun reloaded.
-		new Handle:hData;
+		DataPack hData;
 		CreateDataTimer(fNextAttackNew, Timer_ResetPlaybackRate, hData, TIMER_FLAG_NO_MAPCHANGE);
-		WritePackCell(hData, EntIndexToEntRef(iWeapon));
-		WritePackCell(hData, GetClientUserId(client));
+		hData.WriteCell(EntIndexToEntRef(iWeapon));
+		hData.WriteCell(GetClientUserId(client));
 	}
 	
 	// Tell the gun it can fire ammo faster again after reload
@@ -214,12 +216,12 @@ IncreaseReloadSpeed(client)
 	//PrintToChatAll("new nextattack %f, client nextattack %f, weapon idletime %f", fNextAttackNew, GetEntPropFloat(client, Prop_Send, "m_flNextAttack"), GetEntPropFloat(iWeapon, Prop_Send, "m_flTimeWeaponIdle"));
 }
 
-public Action:Timer_ResetPlaybackRate(Handle:timer, any:data)
+public Action Timer_ResetPlaybackRate(Handle timer, DataPack data)
 {
-	ResetPack(data);
+	data.Reset();
 	
-	new iWeapon = EntRefToEntIndex(ReadPackCell(data));
-	new client = GetClientOfUserId(ReadPackCell(data));
+	int iWeapon = EntRefToEntIndex(data.ReadCell());
+	int client = GetClientOfUserId(data.ReadCell());
 	
 	if(iWeapon != INVALID_ENT_REFERENCE)	
 		SetEntPropFloat(iWeapon, Prop_Send, "m_flPlaybackRate", 1.0);
@@ -232,18 +234,18 @@ public Action:Timer_ResetPlaybackRate(Handle:timer, any:data)
 	return Plugin_Stop;
 }
 
-public Action:OnPlayerRunCmd(client, &buttons, &impulse, Float:vel[3], Float:angles[3], &weapon, &subtype, &cmdnum, &tickcount, &seed, mouse[2])
+public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3], float angles[3], int &weapon, int &subtype, int &cmdnum, int &tickcount, int &seed, int mouse[2])
 {
-	static bool:s_ClientIsReloading[MAXPLAYERS+1];
+	static bool s_ClientIsReloading[MAXPLAYERS+1];
 	if(!IsClientInGame(client))
 		return Plugin_Continue;
 
-	new String:sWeapon[64];
-	new iWeapon = Client_GetActiveWeaponName(client, sWeapon, sizeof(sWeapon));
+	char sWeapon[64];
+	int iWeapon = Client_GetActiveWeaponName(client, sWeapon, sizeof(sWeapon));
 	if(iWeapon == INVALID_ENT_REFERENCE)
 		return Plugin_Continue;
 	
-	new bool:bIsReloading = Weapon_IsReloading(iWeapon);
+	bool bIsReloading = Weapon_IsReloading(iWeapon);
 	// Shotguns don't use m_bInReload but have their own m_reloadState
 	if(!bIsReloading && (StrEqual(sWeapon, "weapon_m3") || StrEqual(sWeapon, "weapon_xm1014")) && GetEntProp(iWeapon, Prop_Send, "m_reloadState") > 0)
 		bIsReloading = true;
@@ -258,12 +260,12 @@ public Action:OnPlayerRunCmd(client, &buttons, &impulse, Float:vel[3], Float:ang
 	return Plugin_Continue;
 }
 
-public Action:Timer_CheckShotgunEnd(Handle:timer, any:data)
+public Action Timer_CheckShotgunEnd(Handle timer, DataPack data)
 {
-	ResetPack(data);
+	data.Reset();
 	
-	new iWeapon = EntRefToEntIndex(ReadPackCell(data));
-	new client = GetClientOfUserId(ReadPackCell(data));
+	int iWeapon = EntRefToEntIndex(data.ReadCell());
+	int client = GetClientOfUserId(data.ReadCell());
 	
 	// Weapon is gone?!
 	if(iWeapon == INVALID_ENT_REFERENCE)
@@ -273,7 +275,7 @@ public Action:Timer_CheckShotgunEnd(Handle:timer, any:data)
 		return Plugin_Stop;
 	}
 	
-	new iOwner = Weapon_GetOwner(iWeapon);
+	int iOwner = Weapon_GetOwner(iWeapon);
 	// Weapon dropped?
 	if(iOwner <= 0)
 	{
@@ -287,7 +289,7 @@ public Action:Timer_CheckShotgunEnd(Handle:timer, any:data)
 		return Plugin_Stop;
 	}
 
-	new iReloadState = GetEntProp(iWeapon, Prop_Send, "m_reloadState");
+	int iReloadState = GetEntProp(iWeapon, Prop_Send, "m_reloadState");
 	
 	// Still reloading
 	if(iReloadState > 0)
@@ -306,9 +308,9 @@ public Action:Timer_CheckShotgunEnd(Handle:timer, any:data)
 }
 
 // Increase shotgun reload
-public Hook_OnReloadPost(weapon, bool:bSuccessful)
+public void Hook_OnReloadPost(int weapon, bool bSuccessful)
 {
-	new client = Weapon_GetOwner(weapon);
+	int client = Weapon_GetOwner(weapon);
 	if(client <= 0)
 		return;
 	
@@ -320,7 +322,7 @@ public Hook_OnReloadPost(weapon, bool:bSuccessful)
 		return;
 	
 	// The upgrade is disabled completely?
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	if(!upgrade[UI_enabled])
 		return;
@@ -330,7 +332,7 @@ public Hook_OnReloadPost(weapon, bool:bSuccessful)
 		return;
 	
 	// Player didn't buy this upgrade yet.
-	new iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
+	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
 	if(iLevel <= 0)
 		return;
 	
@@ -340,20 +342,20 @@ public Hook_OnReloadPost(weapon, bool:bSuccessful)
 		return; // Some other plugin doesn't want this effect to run
 	
 	// Fasten reload!
-	new Float:fReloadIncrease = 1.0 / (1.0 + float(iLevel) * GetConVarFloat(g_hCVSpeedInc));
+	float fReloadIncrease = 1.0 / (1.0 + float(iLevel) * g_hCVSpeedInc.FloatValue);
 	
-	new Float:fIdleTime = GetEntPropFloat(weapon, Prop_Send, "m_flTimeWeaponIdle");
-	new Float:fGameTime = GetGameTime();
-	new Float:fIdleTimeNew = (fIdleTime - fGameTime) * fReloadIncrease + fGameTime;
+	float fIdleTime = GetEntPropFloat(weapon, Prop_Send, "m_flTimeWeaponIdle");
+	float fGameTime = GetGameTime();
+	float fIdleTimeNew = (fIdleTime - fGameTime) * fReloadIncrease + fGameTime;
 	// This is the next time Reload is called for shotguns
 	SetEntPropFloat(weapon, Prop_Send, "m_flTimeWeaponIdle", fIdleTimeNew);
 	
 	//PrintToChatAll("%d reloadpost, success %d, reloadstate %d, gametime %f, wep nextattack %f, orig idle: %f, idle %f, clip1 %d, nextthink %d", weapon, bSuccessful, GetEntProp(weapon, Prop_Send, "m_reloadState"), GetGameTime(), GetEntPropFloat(weapon, Prop_Send, "m_flNextPrimaryAttack"), fIdleTime, GetEntPropFloat(weapon, Prop_Send, "m_flTimeWeaponIdle"), Weapon_GetPrimaryClip(weapon), GetEntProp(weapon, Prop_Send, "m_nNextThinkTick"));
 }
 
-stock ResetClientViewModel(client)
+stock void ResetClientViewModel(int client)
 {
-	new iViewModel = GetEntPropEnt(client, Prop_Send, "m_hViewModel");
+	int iViewModel = GetEntPropEnt(client, Prop_Send, "m_hViewModel");
 	if(iViewModel != INVALID_ENT_REFERENCE)
 		SetEntPropFloat(iViewModel, Prop_Send, "m_flPlaybackRate", 1.0);
 }

--- a/scripting/upgrades/smrpg_upgrade_regen.sp
+++ b/scripting/upgrades/smrpg_upgrade_regen.sp
@@ -1,7 +1,9 @@
 #pragma semicolon 1
 #include <sourcemod>
-#include <smrpg>
 #include <smlib>
+
+#pragma newdecls required
+#include <smrpg>
 
 #undef REQUIRE_PLUGIN
 #include <smrpg_health>
@@ -10,14 +12,14 @@
 
 #define PLUGIN_VERSION "1.0"
 
-new Handle:g_hAmount;
-new Handle:g_hAmountIncrease;
-new Handle:g_hInterval;
-new Handle:g_hIntervalDecrease;
+ConVar g_hCVAmount;
+ConVar g_hCVAmountIncrease;
+ConVar g_hCVInterval;
+ConVar g_hCVIntervalDecrease;
 
-new Handle:g_hRegenerationTimer[MAXPLAYERS+1];
+Handle g_hRegenerationTimer[MAXPLAYERS+1];
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG Upgrade > Health regeneration",
 	author = "Jannik \"Peace-Maker\" Hartung",
@@ -26,23 +28,23 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	LoadTranslations("smrpg_stock_upgrades.phrases");
 }
 
-public OnPluginEnd()
+public void OnPluginEnd()
 {
 	if(SMRPG_UpgradeExists(UPGRADE_SHORTNAME))
 		SMRPG_UnregisterUpgradeType(UPGRADE_SHORTNAME);
 }
 
-public OnAllPluginsLoaded()
+public void OnAllPluginsLoaded()
 {
 	OnLibraryAdded("smrpg");
 }
 
-public OnLibraryAdded(const String:name[])
+public void OnLibraryAdded(const char[] name)
 {
 	// Register this upgrade in SM:RPG
 	if(StrEqual(name, "smrpg"))
@@ -50,14 +52,14 @@ public OnLibraryAdded(const String:name[])
 		SMRPG_RegisterUpgradeType("HP Regeneration", UPGRADE_SHORTNAME, "Regenerates HP regularly.", 15, true, 5, 5, 10, _, SMRPG_BuySell, SMRPG_ActiveQuery);
 		SMRPG_SetUpgradeTranslationCallback(UPGRADE_SHORTNAME, SMRPG_TranslateUpgrade);
 		
-		g_hAmount = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_regen_amount", "1", "Specify the base amount of HP which is regenerated at the first level.", 0, true, 0.1);
-		g_hAmountIncrease = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_regen_amount_inc", "1", "Additional HP to regenerate each interval multiplied by level. (base + inc * (level-1))", 0, true, 0.0);
-		g_hInterval = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_regen_interval", "1.0", "Specify the base interval rate at which HP is regenerated in seconds at the first level.", 0, true, 0.1);
-		g_hIntervalDecrease = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_regen_interval_dec", "0.0", "How much is the base interval reduced for each level?", 0, true, 0.0);
+		g_hCVAmount = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_regen_amount", "1", "Specify the base amount of HP which is regenerated at the first level.", 0, true, 0.1);
+		g_hCVAmountIncrease = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_regen_amount_inc", "1", "Additional HP to regenerate each interval multiplied by level. (base + inc * (level-1))", 0, true, 0.0);
+		g_hCVInterval = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_regen_interval", "1.0", "Specify the base interval rate at which HP is regenerated in seconds at the first level.", 0, true, 0.1);
+		g_hCVIntervalDecrease = SMRPG_CreateUpgradeConVar(UPGRADE_SHORTNAME, "smrpg_regen_interval_dec", "0.0", "How much is the base interval reduced for each level?", 0, true, 0.0);
 	}
 }
 
-public OnClientDisconnect(client)
+public void OnClientDisconnect(int client)
 {
 	ClearHandle(g_hRegenerationTimer[client]);
 }
@@ -65,48 +67,48 @@ public OnClientDisconnect(client)
 /**
  * SM:RPG Upgrade callbacks
  */
-public SMRPG_BuySell(client, UpgradeQueryType:type)
+public void SMRPG_BuySell(int client, UpgradeQueryType type)
 {
 	// Change timer interval to correct interval for new level.
 	ClearHandle(g_hRegenerationTimer[client]);
-	new iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
+	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
 	if(iLevel <= 0)
 		return;
 	
-	new Float:fInterval = GetConVarFloat(g_hInterval) - GetConVarFloat(g_hIntervalDecrease) * (iLevel - 1);
+	float fInterval = g_hCVInterval.FloatValue - g_hCVIntervalDecrease.FloatValue * (iLevel - 1);
 	g_hRegenerationTimer[client] = CreateTimer(fInterval, Timer_IncreaseHealth, GetClientUserId(client), TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 }
 
-public bool:SMRPG_ActiveQuery(client)
+public bool SMRPG_ActiveQuery(int client)
 {
 	// This is a passive effect, so it's always active, if the player got at least level 1
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	return SMRPG_IsEnabled() && upgrade[UI_enabled] && SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME) > 0;
 }
 
-public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:type, String:translation[], maxlen)
+public void SMRPG_TranslateUpgrade(int client, const char[] shortname, TranslationType type, char[] translation, int maxlen)
 {
 	if(type == TranslationType_Name)
 		Format(translation, maxlen, "%T", UPGRADE_SHORTNAME, client);
 	else if(type == TranslationType_Description)
 	{
-		new String:sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
+		char sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
 		StrCat(sDescriptionKey, sizeof(sDescriptionKey), " description");
 		Format(translation, maxlen, "%T", sDescriptionKey, client);
 	}
 }
 
-public Action:Timer_IncreaseHealth(Handle:timer, any:userid)
+public Action Timer_IncreaseHealth(Handle timer, any userid)
 {
-	new client = GetClientOfUserId(userid);
+	int client = GetClientOfUserId(userid);
 	if(!client)
 		return Plugin_Stop;
 
 	if(!SMRPG_IsEnabled())
 		return Plugin_Continue;
 	
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	if(!upgrade[UI_enabled])
 		return Plugin_Continue;
@@ -116,12 +118,12 @@ public Action:Timer_IncreaseHealth(Handle:timer, any:userid)
 		return Plugin_Continue;
 		
 	// Player didn't buy this upgrade yet.
-	new iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
+	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
 	if(iLevel <= 0)
 		return Plugin_Continue;
 		
-	new iOldHealth = GetClientHealth(client);
-	new iMaxHealth = SMRPG_Health_GetClientMaxHealth(client);
+	int iOldHealth = GetClientHealth(client);
+	int iMaxHealth = SMRPG_Health_GetClientMaxHealth(client);
 	// Don't reset the health, if the player gained more by other means.
 	if(iOldHealth >= iMaxHealth)
 		return Plugin_Continue;
@@ -129,8 +131,8 @@ public Action:Timer_IncreaseHealth(Handle:timer, any:userid)
 	if(!SMRPG_RunUpgradeEffect(client, UPGRADE_SHORTNAME))
 		return Plugin_Continue; // Some other plugin doesn't want this effect to run
 	
-	new iIncrease = GetConVarInt(g_hAmount) + GetConVarInt(g_hAmountIncrease) * (iLevel - 1);
-	new iNewHealth = iOldHealth + iIncrease;
+	int iIncrease = g_hCVAmount.IntValue + g_hCVAmountIncrease.IntValue * (iLevel - 1);
+	int iNewHealth = iOldHealth + iIncrease;
 	// Limit the regeneration to the maxhealth.
 	if(iNewHealth > iMaxHealth)
 		iNewHealth = iMaxHealth;

--- a/scripting/upgrades/smrpg_upgrade_speed.sp
+++ b/scripting/upgrades/smrpg_upgrade_speed.sp
@@ -1,15 +1,17 @@
 #pragma semicolon 1
 #include <sourcemod>
 #include <dhooks>
+
+#pragma newdecls required
 #include <smrpg>
 
 #define UPGRADE_SHORTNAME "speed"
 #define PLUGIN_VERSION "1.0"
 
-new Handle:g_hGetSpeed;
-new Handle:g_hCVPercent;
+Handle g_hGetSpeed;
+ConVar g_hCVPercent;
 
-public Plugin:myinfo = 
+public Plugin myinfo = 
 {
 	name = "SM:RPG Upgrade > Speed+",
 	author = "Jannik \"Peace-Maker\" Hartung",
@@ -18,44 +20,44 @@ public Plugin:myinfo =
 	url = "http://www.wcfan.de/"
 }
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	LoadTranslations("smrpg_stock_upgrades.phrases");
 
-	new Handle:hGameConf = LoadGameConfigFile("smrpg_speed.games");
-	if(hGameConf == INVALID_HANDLE)
+	Handle hGameConf = LoadGameConfigFile("smrpg_speed.games");
+	if(hGameConf == null)
 		SetFailState("Gamedata file smrpg_speed.games.txt is missing.");
 	
-	new iOffset = GameConfGetOffset(hGameConf, "GetPlayerMaxSpeed");
-	CloseHandle(hGameConf);
+	int iOffset = GameConfGetOffset(hGameConf, "GetPlayerMaxSpeed");
+	delete hGameConf;
 	
 	if(iOffset == -1)
 		SetFailState("Gamedata is missing the \"GetPlayerMaxSpeed\" offset.");
 	
 	g_hGetSpeed = DHookCreate(iOffset, HookType_Entity, ReturnType_Float, ThisPointer_CBaseEntity, Hook_GetPlayerMaxSpeedPost);
-	if(g_hGetSpeed == INVALID_HANDLE)
+	if(g_hGetSpeed == null)
 		SetFailState("Failed to create hook on \"GetPlayerMaxSpeed\".");
 	
 	// Account for late loading
-	for(new i=1;i<=MaxClients;i++)
+	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i))
 			OnClientPutInServer(i);
 	}
 }
 
-public OnPluginEnd()
+public void OnPluginEnd()
 {
 	if(SMRPG_UpgradeExists(UPGRADE_SHORTNAME))
 		SMRPG_UnregisterUpgradeType(UPGRADE_SHORTNAME);
 }
 
-public OnAllPluginsLoaded()
+public void OnAllPluginsLoaded()
 {
 	OnLibraryAdded("smrpg");
 }
 
-public OnLibraryAdded(const String:name[])
+public void OnLibraryAdded(const char[] name)
 {
 	// Register this upgrade in SM:RPG
 	if(StrEqual(name, "smrpg"))
@@ -66,7 +68,7 @@ public OnLibraryAdded(const String:name[])
 	}
 }
 
-public OnClientPutInServer(client)
+public void OnClientPutInServer(int client)
 {
 	DHookEntity(g_hGetSpeed, true, client);
 }
@@ -74,25 +76,25 @@ public OnClientPutInServer(client)
 /**
  * SM:RPG Upgrade callbacks
  */
-public SMRPG_BuySell(client, UpgradeQueryType:type)
+public void SMRPG_BuySell(int client, UpgradeQueryType type)
 {
 	// Nothing to apply here immediately after someone buys this upgrade.
 }
 
-public bool:SMRPG_ActiveQuery(client)
+public bool SMRPG_ActiveQuery(int client)
 {
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	return SMRPG_IsEnabled() && upgrade[UI_enabled] && SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME) > 0;
 }
 
-public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:type, String:translation[], maxlen)
+public void SMRPG_TranslateUpgrade(int client, const char[] shortname, TranslationType type, char[] translation, int maxlen)
 {
 	if(type == TranslationType_Name)
 		Format(translation, maxlen, "%T", UPGRADE_SHORTNAME, client);
 	else if(type == TranslationType_Description)
 	{
-		new String:sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
+		char sDescriptionKey[MAX_UPGRADE_SHORTNAME_LENGTH+12] = UPGRADE_SHORTNAME;
 		StrCat(sDescriptionKey, sizeof(sDescriptionKey), " description");
 		Format(translation, maxlen, "%T", sDescriptionKey, client);
 	}
@@ -101,7 +103,7 @@ public SMRPG_TranslateUpgrade(client, const String:shortname[], TranslationType:
 /**
  * Hook callbacks
  */
-public MRESReturn:Hook_GetPlayerMaxSpeedPost(client, Handle:hReturn)
+public MRESReturn Hook_GetPlayerMaxSpeedPost(int client, Handle hReturn)
 {
 	if(!SMRPG_IsEnabled())
 		return MRES_Ignored;
@@ -111,21 +113,21 @@ public MRESReturn:Hook_GetPlayerMaxSpeedPost(client, Handle:hReturn)
 		return MRES_Ignored;
 	
 	// Upgrade enabled?
-	new upgrade[UpgradeInfo];
+	int upgrade[UpgradeInfo];
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	if(!upgrade[UI_enabled])
 		return MRES_Ignored;
 	
-	new iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
+	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
 	if(iLevel <= 0)
 		return MRES_Ignored;
 	
 	if(!SMRPG_RunUpgradeEffect(client, UPGRADE_SHORTNAME))
 		return MRES_Ignored; // Some other plugin doesn't want this effect to run
 	
-	new Float:fCurrentMaxSpeed = DHookGetReturn(hReturn);
+	float fCurrentMaxSpeed = DHookGetReturn(hReturn);
 	// Increase maxspeed depending on level
-	new Float:fMaxSpeedIncrease = fCurrentMaxSpeed * float(iLevel) * GetConVarFloat(g_hCVPercent);
+	float fMaxSpeedIncrease = fCurrentMaxSpeed * float(iLevel) * g_hCVPercent.FloatValue;
 	
 	DHookSetReturn(hReturn, fCurrentMaxSpeed+fMaxSpeedIncrease);
 	return MRES_Override;


### PR DESCRIPTION
Convert the plugin to the SourceMod 1.7+ transitional syntax. Now requires SM 1.7+, but 1.8 has been stable for a while, so shouldn't be too much of a worry.