### PR TITLE
Add RPG banning

### DIFF
--- a/configs/sql-init-scripts/mysql/smrpg_ban.sql
+++ b/configs/sql-init-scripts/mysql/smrpg_ban.sql
@@ -1,0 +1,10 @@
+-- Table to store the rpg bans of smrpg_ban.smx
+CREATE TABLE bans (
+	ban_id INTEGER PRIMARY KEY AUTO_INCREMENT,
+	name VARCHAR(128) NOT NULL,
+	steamid INTEGER NOT NULL,
+	start INTEGER NOT NULL,
+	length INTEGER NOT NULL,
+	reason VARCHAR(256) NOT NULL,
+	unban_time INTEGER DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/configs/sql-init-scripts/sqlite/smrpg_ban.sql
+++ b/configs/sql-init-scripts/sqlite/smrpg_ban.sql
@@ -1,0 +1,10 @@
+-- Table to store the rpg bans of smrpg_ban.smx
+CREATE TABLE bans (
+	ban_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name VARCHAR(128) NOT NULL,
+	steamid INTEGER NOT NULL,
+	start INTEGER NOT NULL,
+	length INTEGER NOT NULL,
+	reason VARCHAR(256) NOT NULL,
+	unban_time INTEGER DEFAULT NULL
+);

--- a/scripting/include/smrpg/smrpg_database.inc
+++ b/scripting/include/smrpg/smrpg_database.inc
@@ -21,3 +21,17 @@ native bool SMRPG_ResetAllPlayers(const char[] sReason, bool bHardReset=false);
  * This obeys the settings for smrpg_enable and smrpg_save_data.
  */
 native void SMRPG_FlushDatabase();
+
+/**
+ * Checks if the database connection is available and fires the SMRPG_OnDatabaseConnected function in the calling plugin in that case.
+ * Should be used in OnPluginStart to support late loading.
+ */
+native void SMRPG_CheckDatabaseConnection();
+
+/**
+ * Called when the connection to the SQL database was established.
+ * The database handle can be saved to execute custom queries against the SM:RPG database.
+ *
+ * @param database      The database handle.
+ */
+forward void SMRPG_OnDatabaseConnected(Database database);

--- a/scripting/smrpg.sp
+++ b/scripting/smrpg.sp
@@ -226,6 +226,7 @@ public void OnPluginStart()
 	RegisterAdminCommands();
 	RegisterPlayerForwards();
 	RegisterTopMenuForwards();
+	RegisterDatabaseForwards();
 	RegisterStatsForwards();
 	RegisterUpgradeForwards();
 	RegisterSettingsForwards();

--- a/scripting/smrpg/smrpg_menu.sp
+++ b/scripting/smrpg/smrpg_menu.sp
@@ -416,11 +416,11 @@ public int Menu_ConfirmSell(Menu menu, MenuAction action, int param1, int param2
 		int iItemIndex = StringToInt(sInfo);
 		int upgrade[InternalUpgradeInfo];
 		GetUpgradeByIndex(iItemIndex, upgrade);
-		SellClientUpgrade(param1, iItemIndex);
-		
 		char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
 		GetUpgradeTranslatedName(param1, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
-		Client_PrintToChat(param1, false, "%t", "Upgrade sold", sTranslatedName, GetClientPurchasedUpgradeLevel(param1, iItemIndex)+1);
+		
+		if (SellClientUpgrade(param1, iItemIndex))
+			Client_PrintToChat(param1, false, "%t", "Upgrade sold", sTranslatedName, GetClientPurchasedUpgradeLevel(param1, iItemIndex));
 		
 		g_hRPGTopMenu.Display(param1, TopMenuPosition_LastCategory);
 	}

--- a/scripting/smrpg_ban.sp
+++ b/scripting/smrpg_ban.sp
@@ -1,0 +1,258 @@
+#pragma semicolon 1
+#include <smlib>
+#pragma newdecls required
+#include <smrpg>
+
+#define MAX_BAN_REASON_LENGTH 256
+
+enum BanInfo
+{
+	BanInfo_AccountId,
+	BanInfo_Time,
+	BanInfo_StartTime,
+	String:BanInfo_Reason[MAX_BAN_REASON_LENGTH]
+};
+StringMap g_hBans;
+bool g_bClientBanned[MAXPLAYERS+1];
+int g_iClientBanNotificationCount[MAXPLAYERS+1];
+
+public Plugin myinfo = 
+{
+	name = "SM:RPG > Ban players",
+	author = "Peace-Maker",
+	description = "Ban players from RPG features.",
+	version = SMRPG_VERSION,
+	url = "https://www.wcfan.de/"
+}
+
+public void OnPluginStart()
+{
+	RegAdminCmd("sm_rpgban", Cmd_OnRPGBan, ADMFLAG_BAN, "Ban a player from RPG features. Usage sm_rpgban <name|#steamid|#userid> <length in minutes> <reason>");
+	RegAdminCmd("sm_rpgunban", Cmd_OnRPGUnban, ADMFLAG_BAN, "Unban a player from RPG features. Usage sm_rpgunban <name|#steamid|#userid>");
+
+	HookEvent("player_spawn", Event_OnPlayerSpawn);
+
+	// TODO: Integrate RPGBan Player into admin menu.
+	// TODO: Make bans persistent in database.
+	// TODO: Make messages translatable.
+
+	g_hBans = new StringMap();
+	LoadTranslations("common.phrases");
+}
+
+public void OnClientAuthorized(int client, const char[] auth)
+{
+	int iBanInfo[BanInfo];
+	if (GetClientBanInfo(client, iBanInfo))
+		g_bClientBanned[client] = true;
+}
+
+public void OnClientDisconnect(int client)
+{
+	g_bClientBanned[client] = false;
+	g_iClientBanNotificationCount[client] = 0;
+}
+
+public void Event_OnPlayerSpawn(Event event, const char[] name, bool dontBroadcast)
+{
+	int client = GetClientOfUserId(event.GetInt("userid"));
+	if (!client || !IsPlayerAlive(client))
+		return;
+
+	if (!IsClientBanned(client))
+		return;
+
+	// Don't spam this every spawn.
+	if (g_iClientBanNotificationCount[client] > 2)
+		return;
+
+	// TODO: Show time until ban expires.
+	Client_PrintToChat(client, false, "{OG}SM:RPG{N} > {G}You are banned from RPG features. You will gain no experience nor be able to use your upgrades.");
+	g_iClientBanNotificationCount[client]++;
+}
+
+/**
+ * SMRPG forwards.
+ */
+public Action SMRPG_OnAddExperience(int client, const char[] reason, int &iExperience, int other)
+{
+	// Don't give him any regular experience.
+	if(!StrEqual(reason, ExperienceReason_Admin) && IsClientBanned(client))
+	{
+		return Plugin_Handled;
+	}
+	return Plugin_Continue;
+}
+
+// Don't let him use any of his upgrades.
+public Action SMRPG_OnUpgradeEffect(int target, const char[] shortname, int issuer)
+{
+	if (IsClientBanned(issuer))
+		return Plugin_Handled;
+	return Plugin_Continue;
+}
+
+// Don't let him buy upgrades.
+public Action SMRPG_OnBuyUpgrade(int client, const char[] shortname, int newlevel)
+{
+	if (IsClientBanned(client))
+		return Plugin_Handled;
+	return Plugin_Continue;
+}
+
+// Don't let him sell upgrades.
+public Action SMRPG_OnSellUpgrade(int client, const char[] shortname, int newlevel)
+{
+	if (IsClientBanned(client))
+		return Plugin_Handled;
+	return Plugin_Continue;
+}
+
+/**
+ * Command callbacks
+ */
+public Action Cmd_OnRPGBan(int client, int args)
+{
+	if (args < 4)
+	{
+		ReplyToCommand(client, "Usage sm_rpgban <name|#steamid|#userid> <length in minutes> <reason>");
+		return Plugin_Handled;
+	}
+
+	char sTarget[MAX_NAME_LENGTH];
+	GetCmdArg(1, sTarget, sizeof(sTarget));
+	int iTarget = FindTarget(client, sTarget, true, true);
+	if (iTarget == -1)
+		return Plugin_Handled;
+
+	if (!IsClientAuthorized(iTarget))
+	{
+		ReplyToCommand(client, "%N isn't authorized with steam yet. Try again later.", iTarget);
+		return Plugin_Handled;
+	}
+
+	// TODO: Open menu when options are missing.
+
+	char sTime[32];
+	GetCmdArg(2, sTime, sizeof(sTime));
+	TrimString(sTime);
+	int iTime;
+	if (StringToIntEx(sTime, iTime) != strlen(sTime))
+	{
+		ReplyToCommand(client, "Failed to parse the length of the ban. \"%s\" is not a number.", sTime);
+		return Plugin_Handled;
+	}
+
+
+	// Get the reason
+	char sReason[MAX_BAN_REASON_LENGTH];
+	GetCmdArg(3, sReason, sizeof(sReason));
+	TrimString(sReason);
+
+	BanClientFromRPG(client, iTarget, iTime, sReason);
+
+	return Plugin_Handled;
+}
+
+public Action Cmd_OnRPGUnban(int client, int args)
+{
+	// Require all arguments for RCON.
+	if (args < 2)
+	{
+		ReplyToCommand(client, "Usage sm_rpgunban <name|#steamid|#userid>");
+		return Plugin_Handled;
+	}
+
+	char sTarget[MAX_NAME_LENGTH];
+	GetCmdArgString(sTarget, sizeof(sTarget));
+	StripQuotes(sTarget);
+	int iTarget = FindTarget(client, sTarget, true, true);
+	if (iTarget == -1)
+		return Plugin_Handled;
+
+	if (!IsClientBanned(iTarget))
+	{
+		ReplyToCommand(client, "%N is not banned from RPG.", iTarget);
+		return Plugin_Handled;
+	}
+
+	UnbanClientFromRPG(iTarget);
+	LogAction(client, iTarget, "%L unbanned %L from RPG features.", client, iTarget);
+	return Plugin_Handled;
+}
+
+void BanClientFromRPG(int client, int iTarget, int iTime, const char[] sReason)
+{
+	int iBanInfo[BanInfo];
+	if (IsClientBanned(iTarget))
+	{
+		GetClientBanInfo(iTarget, iBanInfo);
+		Client_PrintToChat(client, false, "{OG}SM:RPG{N} > {G}%N was banned before. Changed the ban from %d minutes to %d minutes. (Old reason: \"%s\")", iBanInfo[BanInfo_Time], iTime, iBanInfo[BanInfo_Reason]);
+	}
+
+	iBanInfo[BanInfo_AccountId] = GetSteamAccountID(iTarget);
+	iBanInfo[BanInfo_Time] = iTime;
+	iBanInfo[BanInfo_StartTime] = GetTime();
+	strcopy(iBanInfo[BanInfo_Reason], MAX_BAN_REASON_LENGTH, sReason);
+
+	char sAccountId[64];
+	IntToString(iBanInfo[BanInfo_AccountId], sAccountId, sizeof(sAccountId));
+	g_hBans.SetArray(sAccountId, iBanInfo[0], view_as<int>(BanInfo));
+	g_bClientBanned[iTarget] = true;
+
+	LogAction(client, iTarget, "%L banned %L from RPG features (time %d) (reason \"%s\")", client, iTarget, iTime, sReason);
+	ShowActivity2(client, "SM:RPG", "%N banned %N from RPG features for %d minutes. Reason: %s", client, iTarget, iTime, sReason);
+}
+
+void UnbanClientFromRPG(int client)
+{
+	g_bClientBanned[client] = false;
+
+	char sAccountId[64];
+	sAccountId = GetClientAccountIDString(client);
+	g_hBans.Remove(sAccountId);
+	Client_PrintToChat(client, false, "{OG}SM:RPG{N} > {G}Your RPG ban expired. You may play normally again. Behave yourself!");
+}
+
+bool IsClientBanned(int client)
+{
+	if (!g_bClientBanned[client])
+		return false;
+
+	int iBanInfo[BanInfo];
+	if (!GetClientBanInfo(client, iBanInfo))
+		return false;
+
+	// Permanent ban.
+	if (!iBanInfo[BanInfo_Time])
+		return true;
+
+	// Make sure the ban still ends in the future.
+	bool bBanStillValid = (iBanInfo[BanInfo_StartTime] + iBanInfo[BanInfo_Time]*60) > GetTime();
+	if (!bBanStillValid)
+		UnbanClientFromRPG(client);
+
+	return bBanStillValid;
+}
+
+bool GetClientBanInfo(int client, int iBanInfo[BanInfo])
+{
+	char sAccountId[64];
+	sAccountId = GetClientAccountIDString(client);
+	if (!sAccountId[0])
+		return false;
+
+	return g_hBans.GetArray(sAccountId, iBanInfo[0], view_as<int>(BanInfo));
+}
+
+char GetClientAccountIDString(int client)
+{
+	char sAccountId[64];
+
+	if (!IsClientAuthorized(client))
+		return sAccountId;
+
+	int iAccountId = GetSteamAccountID(client);
+	IntToString(iAccountId, sAccountId, sizeof(sAccountId));
+	return sAccountId;
+}

--- a/scripting/smrpg_ban.sp
+++ b/scripting/smrpg_ban.sp
@@ -560,12 +560,16 @@ void BanClientFromRPG(int client, int iTarget, int iTime, const char[] sReason)
 	}
 	else
 	{
-		char sQuery[1024];
+		char sQuery[1024], sName[MAX_NAME_LENGTH], sEscapedName[MAX_NAME_LENGTH*2+1], sEscapedReason[MAX_BAN_REASON_LENGTH*2+1];
+		GetClientName(iTarget, sName, sizeof(sName));
+		g_hDatabase.Escape(sName, sEscapedName, sizeof(sEscapedName));
+		g_hDatabase.Escape(iBanInfo[BanInfo_Reason], sEscapedReason, sizeof(sEscapedReason));
+
 		// New ban
 		if (iBanInfo[BanInfo_DatabaseId] == -1)
-			g_hDatabase.Format(sQuery, sizeof(sQuery), "INSERT INTO `%s` (name, steamid, start, length, reason) VALUES ('%N', %d, %d, %d, '%s')", TBL_BANS, iTarget, iBanInfo[BanInfo_AccountId], iBanInfo[BanInfo_StartTime], iBanInfo[BanInfo_Time], iBanInfo[BanInfo_Reason]);
+			Format(sQuery, sizeof(sQuery), "INSERT INTO `%s` (name, steamid, start, length, reason) VALUES ('%s', %d, %d, %d, '%s')", TBL_BANS, sEscapedName, iBanInfo[BanInfo_AccountId], iBanInfo[BanInfo_StartTime], iBanInfo[BanInfo_Time], sEscapedReason);
 		else
-			g_hDatabase.Format(sQuery, sizeof(sQuery), "INSERT INTO `%s` (ban_id, name, steamid, start, length, reason) VALUES (%d, '%N', %d, %d, %d, '%s') ON DUPLICATE KEY UPDATE name=VALUES(name), steamid=VALUES(steamid), start=VALUES(start), length=VALUES(length), reason=VALUES(reason)", TBL_BANS, iBanInfo[BanInfo_DatabaseId], iTarget, iBanInfo[BanInfo_AccountId], iBanInfo[BanInfo_StartTime], iBanInfo[BanInfo_Time], iBanInfo[BanInfo_Reason]);
+			Format(sQuery, sizeof(sQuery), "INSERT INTO `%s` (ban_id, name, steamid, start, length, reason) VALUES (%d, '%s', %d, %d, %d, '%s') ON DUPLICATE KEY UPDATE name=VALUES(name), steamid=VALUES(steamid), start=VALUES(start), length=VALUES(length), reason=VALUES(reason)", TBL_BANS, iBanInfo[BanInfo_DatabaseId], sEscapedName, iBanInfo[BanInfo_AccountId], iBanInfo[BanInfo_StartTime], iBanInfo[BanInfo_Time], sEscapedReason);
 		g_hDatabase.Query(SQL_InsertBan, sQuery, iBanInfo[BanInfo_AccountId]);
 	}
 }

--- a/translations/de/smrpg_ban.phrases.txt
+++ b/translations/de/smrpg_ban.phrases.txt
@@ -1,0 +1,94 @@
+"Phrases"
+{
+	"RPG Ban Player"
+	{
+		"de"			"Spieler vom RPG bannen"
+	}
+	
+	"You are banned"
+	{
+		"de"			"Du wurdest vom RPG gebannt. Du bekommst keine Erfahrung und kannst deine Upgrades nicht benutzen."
+	}
+	
+	"Cannot buy upgrades"
+	{
+		"de"			"Du wurdest vom RPG gebannt. Du kannst gerade keine Upgrades kaufen."
+	}
+	
+	"Cannot sell upgrades"
+	{
+		"de"			"Du wurdest vom RPG gebannt. Du kannst gerade keine Upgrades verkaufen."
+	}
+	
+	"Not authorized yet"
+	{
+		// 1: Name of the player.
+		"de"			"{1} ist noch nicht von Steam authentifiziert. Probiere es später nochmal."
+	}
+	
+	"Invalid ban length"
+	{
+		// 1: String that was entered as length in the command.
+		"de"			"Konnte die Länge des Banns nicht lesen. \"{1}\" ist keine Zahl."
+	}
+	
+	"Player is not banned"
+	{
+		// 1: Name of the player.
+		"de"			"{1} ist nicht vom RPG gebannt."
+	}
+	
+	"Player unbanned"
+	{
+		// 1: Name of the player.
+		"de"			"{1} wurde vom RPG entbannt."
+	}
+	
+	"Select player to ban"
+	{
+		"de"			"Wähle den vom RPG zu bannenden Spieler:"
+	}
+
+	"Select length of ban"
+	{
+		// 1: Name of the player.
+		"de"			"Wähle die Länge des RPG Banns für {1}:"
+	}
+
+	"Select reason for ban"
+	{
+		// 1: Name of the player.
+		"de"			"Wähle den Grund für den RPG Bann von {1}:"
+	}
+
+	"Already banned, change length"
+	{
+		// 1: Name of the player.
+		// 2: Old length of the ban in minutes.
+		// 3: New length of the ban in minutes.
+		// 4: Old reason for the ban.
+		"de"			"{1} ist bereits gebannt. Die Bannlänge wurde von {2} Minuten auf {3} Minuten geändert. (Alter Grund: \"{4}\")"
+	}
+
+	"Player was banned"
+	{
+		// 1: Name of the admin who is banning the player.
+		// 2: Name of the banned player.
+		// 3: Length of the ban in minutes.
+		// 4: Reason for the ban.
+		"de"			"{1} hat {2} für {3} Minuten vom RPG gebannt. Grund: {4}"
+	}
+
+	"Player was banned permanently"
+	{
+		// 1: Name of the admin who is banning the player.
+		// 2: Name of the banned player.
+		// 3: Reason for the ban.
+		"de"			"{1} hat {2} permanent vom RPG gebannt. Grund: {3}"
+	}
+	
+	"Ban expired"
+	{
+		"de"			"Dein RPG Bann ist abgelaufen. Du kannst wieder normal spielen. Sei artig!"
+	}
+}

--- a/translations/smrpg_ban.phrases.txt
+++ b/translations/smrpg_ban.phrases.txt
@@ -1,0 +1,103 @@
+"Phrases"
+{
+	"RPG Ban Player"
+	{
+		"en"			"Ban player from RPG"
+	}
+	
+	"You are banned"
+	{
+		"en"			"You are banned from RPG features. You will gain no experience nor be able to use your upgrades."
+	}
+	
+	"Cannot buy upgrades"
+	{
+		"en"			"You are banned from RPG features. You cannot buy upgrades right now."
+	}
+	
+	"Cannot sell upgrades"
+	{
+		"en"			"You are banned from RPG features. You cannot sell upgrades right now."
+	}
+	
+	"Not authorized yet"
+	{
+		// 1: Name of the player.
+		"#format"		"{1:N}"
+		"en"			"{1} isn't authorized with steam yet. Try again later."
+	}
+	
+	"Invalid ban length"
+	{
+		// 1: String that was entered as length in the command.
+		"#format"		"{1:s}"
+		"en"			"Failed to parse the length of the ban. \"{1}\" is not a number."
+	}
+	
+	"Player is not banned"
+	{
+		// 1: Name of the player.
+		"#format"		"{1:N}"
+		"en"			"{1} is not banned from RPG."
+	}
+	
+	"Player unbanned"
+	{
+		// 1: Name of the player.
+		"#format"		"{1:N}"
+		"en"			"{1} was unbanned from RPG."
+	}
+	
+	"Select player to ban"
+	{
+		"en"			"Select player to ban from RPG:"
+	}
+
+	"Select length of ban"
+	{
+		// 1: Name of the player.
+		"#format"		"{1:N}"
+		"en"			"Select length of RPG ban for {1}:"
+	}
+
+	"Select reason for ban"
+	{
+		// 1: Name of the player.
+		"#format"		"{1:N}"
+		"en"			"Select the reason for the RPG ban for {1}:"
+	}
+
+	"Already banned, change length"
+	{
+		// 1: Name of the player.
+		// 2: Old length of the ban in minutes.
+		// 3: New length of the ban in minutes.
+		// 4: Old reason for the ban.
+		"#format"		"{1:N},{2:d},{3:d},{4:s}"
+		"en"			"{1} is already banned. Changed the ban from {2} minutes to {3} minutes. (Old reason: \"{4}\")"
+	}
+
+	"Player was banned"
+	{
+		// 1: Name of the admin who is banning the player.
+		// 2: Name of the banned player.
+		// 3: Length of the ban in minutes.
+		// 4: Reason for the ban.
+		"#format"		"{1:N},{2:N},{3:d},{4:s}"
+		"en"			"{1} banned {2} from RPG features for {3} minutes. Reason: {4}"
+	}
+
+	"Player was banned permanently"
+	{
+		// 1: Name of the admin who is banning the player.
+		// 2: Name of the banned player.
+		// 3: Reason for the ban.
+		"#format"		"{1:N},{2:N},{3:s}"
+		"en"			"{1} banned {2} from RPG features permanently. Reason: {3}"
+	}
+	
+	"Ban expired"
+	{
+		"en"			"Your RPG ban expired. You may play normally again. Behave yourself!"
+	}
+}


### PR DESCRIPTION
See #275 for the discussion.

Adds two new commands `sm_rpgban` and `sm_rpgunban` to block players from using, buying and selling their upgrades. They are still able to enter the server normally, just don't have access to their bought upgrades.