### PR TITLE
Switch to new-style enum structs

### DIFF
--- a/scripting/include/smrpg/smrpg_upgrades.inc
+++ b/scripting/include/smrpg/smrpg_upgrades.inc
@@ -262,20 +262,20 @@ native bool SMRPG_UpgradeExists(const char[] shortname);
 /**
  * Detailed upgrade info of some upgrade.
  */
-enum UpgradeInfo
+enum struct UpgradeInfo
 {
-	bool:UI_enabled, // upgrade enabled?
-	UI_maxLevelBarrier, // upper limit of maxlevel setting. Can't set maxlevel higher than that.
-	UI_maxLevel, // Maximal level a player can get for this upgrade
-	UI_startCost, // The amount of credits the first level costs
-	UI_incCost, // The amount of credits each level costs more
-	UI_adminFlag, // The admin flag(s) (ADMFLAG_*) this upgrade is restricted to. (See SMRPG_CheckUpgradeAccess and SMRPG_RunUpgradeEffect)
-	UI_teamlock, // The team this upgrade is restricted to. 0 = Disabled, 2 = RED/Terrorist team, 3 = BLU/Counter-Terrorist team
-	String:UI_name[MAX_UPGRADE_NAME_LENGTH], // Upgrade readable name as given when registering the upgrade.
-	String:UI_shortName[MAX_UPGRADE_SHORTNAME_LENGTH], // shortname used as unique identifier in all commands and database
-	String:UI_description[MAX_UPGRADE_DESCRIPTION_LENGTH], // Upgrade description as given when registering the upgrade.
-	UI_startLevel // Initial level of upgrade when players first join the server.
-};
+	bool enabled; // upgrade enabled?
+	int maxLevelBarrier; // upper limit of maxlevel setting. Can't set maxlevel higher than that.
+	int maxLevel; // Maximal level a player can get for this upgrade
+	int startCost; // The amount of credits the first level costs
+	int incCost; // The amount of credits each level costs more
+	int adminFlag; // The admin flag(s) (ADMFLAG_*) this upgrade is restricted to. (See SMRPG_CheckUpgradeAccess and SMRPG_RunUpgradeEffect)
+	int teamlock; // The team this upgrade is restricted to. 0 = Disabled, 2 = RED/Terrorist team, 3 = BLU/Counter-Terrorist team
+	char name[MAX_UPGRADE_NAME_LENGTH]; // Upgrade readable name as given when registering the upgrade.
+	char shortName[MAX_UPGRADE_SHORTNAME_LENGTH]; // shortname used as unique identifier in all commands and database
+	char description[MAX_UPGRADE_DESCRIPTION_LENGTH]; // Upgrade description as given when registering the upgrade.
+	int startLevel; // Initial level of upgrade when players first join the server.
+}
 
 /**
  * Get the UpgradeInfo of an upgrade.
@@ -285,7 +285,21 @@ enum UpgradeInfo
  * @param size           The size of the buffer array.
  * @error Unkown upgrade shortname.
  */
-native void SMRPG_GetUpgradeInfo(const char[] shortname, upgrade[UpgradeInfo], int size=view_as<int>(UpgradeInfo));
+native void SMRPG_GetUpgradeInfo(const char[] shortname, any upgrade[sizeof(UpgradeInfo)], int size=sizeof(UpgradeInfo));
+
+/**
+ * Returns if an upgrade is enabled or disabled.
+ *
+ * @param shortname      The shortname of the upgrade to check.
+ * @return               True if upgrade is enabled, false otherwise.
+ * @error Unknown upgrade shortname.
+ */
+stock bool SMRPG_IsUpgradeEnabled(const char[] shortname)
+{
+	UpgradeInfo upgrade;
+	SMRPG_GetUpgradeInfo(shortname, upgrade);
+	return upgrade.enabled;
+}
 
 /**
  * Ask the plugin controlling an upgrade to remove all active effects from a client.

--- a/scripting/smrpg.sp
+++ b/scripting/smrpg.sp
@@ -469,7 +469,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	{
 		// Reset his afk timer when he uses a weapon.
 		if(buttons & (IN_ATTACK|IN_ATTACK2))
-			g_PlayerAFKInfo[client][AFK_startTime] = 0;
+			g_PlayerAFKInfo[client].startTime = 0;
 		
 		// Remove spawn protection if the player presses any buttons.
 		if(buttons > 0)
@@ -506,7 +506,7 @@ public void Event_OnPlayerSpawn(Event event, const char[] error, bool dontBroadc
 		return;
 	
 	// Save the spawn time so we don't count the new spawn position as if the player moved himself
-	g_PlayerAFKInfo[client][AFK_spawnTime] = GetTime();
+	g_PlayerAFKInfo[client].spawnTime = GetTime();
 	// Protect him and don't give any experience to actions against him until he presses some button.
 	g_bPlayerSpawnProtected[client] = true;
 }
@@ -520,7 +520,7 @@ public void Event_OnPlayerDeath(Event event, const char[] error, bool dontBroadc
 		return;
 	
 	// Save when the player died.
-	g_PlayerAFKInfo[victim][AFK_deathTime] = GetTime();
+	g_PlayerAFKInfo[victim].deathTime = GetTime();
 	
 	if(attacker <= 0)
 		return;

--- a/scripting/smrpg/smrpg_admincommands.sp
+++ b/scripting/smrpg/smrpg_admincommands.sp
@@ -58,18 +58,18 @@ public Action Cmd_PlayerInfo(int client, int args)
 	ReplyToCommand(client, "SM:RPG: ----------");
 	ReplyToCommand(client, "SM:RPG %N: ", iTarget);
 	
-	int playerInfo[PlayerInfo];
+	PlayerInfo playerInfo;
 	GetClientRPGInfo(iTarget, playerInfo);
 	
 	char sSteamID[64];
 	GetClientAuthId(iTarget, AuthId_Engine, sSteamID, sizeof(sSteamID));
-	ReplyToCommand(client, "SM:RPG Info: Index: %d, UserID: %d, SteamID: %s, Database ID: %d, AFK: %d", iTarget, GetClientUserId(iTarget), sSteamID, playerInfo[PLR_dbId], IsClientAFK(iTarget));
+	ReplyToCommand(client, "SM:RPG Info: Index: %d, UserID: %d, SteamID: %s, Database ID: %d, AFK: %d", iTarget, GetClientUserId(iTarget), sSteamID, playerInfo.dbId, IsClientAFK(iTarget));
 	
 	ReplyToCommand(client, "SM:RPG Stats: Level: %d, Experience: %d/%d, Credits: %d, Rank: %d/%d", GetClientLevel(iTarget), GetClientExperience(iTarget), Stats_LvlToExp(GetClientLevel(iTarget)), GetClientCredits(iTarget), GetClientRank(iTarget), GetRankCount());
 	
 	ReplyToCommand(client, "SM:RPG Upgrades: ");
 	int iSize = GetUpgradeCount();
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	char sPermission[30];
 	for(int i=0;i<iSize;i++)
 	{
@@ -78,17 +78,17 @@ public Action Cmd_PlayerInfo(int client, int args)
 			continue;
 		
 		sPermission[0] = 0;
-		if(upgrade[UPGR_adminFlag] > 0)
+		if(upgrade.adminFlag > 0)
 		{
-			GetAdminFlagStringFromBits(upgrade[UPGR_adminFlag], sPermission, sizeof(sPermission));
+			GetAdminFlagStringFromBits(upgrade.adminFlag, sPermission, sizeof(sPermission));
 			Format(sPermission, sizeof(sPermission), " (admflag: %s)", sPermission);
 		}
 		
 		if(!HasAccessToUpgrade(iTarget, upgrade))
 			Format(sPermission, sizeof(sPermission), " NO ACCESS:");
-		else if(upgrade[UPGR_adminFlag] > 0)
+		else if(upgrade.adminFlag > 0)
 			Format(sPermission, sizeof(sPermission), " OK:");
-		ReplyToCommand(client, "SM:RPG - %s%s Level %d (Selected %d)", upgrade[UPGR_name], sPermission, GetClientPurchasedUpgradeLevel(iTarget, i), GetClientSelectedUpgradeLevel(iTarget, i));
+		ReplyToCommand(client, "SM:RPG - %s%s Level %d (Selected %d)", upgrade.name, sPermission, GetClientPurchasedUpgradeLevel(iTarget, i), GetClientSelectedUpgradeLevel(iTarget, i));
 	}
 	ReplyToCommand(client, "SM:RPG: ----------");
 	
@@ -654,7 +654,7 @@ public Action Cmd_ListUpgrades(int client, int args)
 {
 	int iSize = GetUpgradeCount();
 	ReplyToCommand(client, "There are %d upgrades registered.", iSize);
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	int iUnavailableCount;
 	char sPluginFile[64], sPermissions[30];
 	for(int i=0;i<iSize;i++)
@@ -666,10 +666,10 @@ public Action Cmd_ListUpgrades(int client, int args)
 			continue;
 		}
 		
-		GetPluginFilename(upgrade[UPGR_plugin], sPluginFile, sizeof(sPluginFile));
-		GetAdminFlagStringFromBits(upgrade[UPGR_adminFlag], sPermissions, sizeof(sPermissions));
+		GetPluginFilename(upgrade.plugin, sPluginFile, sizeof(sPluginFile));
+		GetAdminFlagStringFromBits(upgrade.adminFlag, sPermissions, sizeof(sPermissions));
 		
-		ReplyToCommand(client, "%d. [%s] %s (%s). Maxlevel: %d, maxlevel barrier: %d, start cost: %d, increasing cost: %d, adminflag: %s, plugin: %s", i-iUnavailableCount, (upgrade[UPGR_enabled] ? "ON" : "OFF"), upgrade[UPGR_name], upgrade[UPGR_shortName], upgrade[UPGR_maxLevel], upgrade[UPGR_maxLevelBarrier], upgrade[UPGR_startCost], upgrade[UPGR_incCost], sPermissions, sPluginFile);
+		ReplyToCommand(client, "%d. [%s] %s (%s). Maxlevel: %d, maxlevel barrier: %d, start cost: %d, increasing cost: %d, adminflag: %s, plugin: %s", i-iUnavailableCount, (upgrade.enabled ? "ON" : "OFF"), upgrade.name, upgrade.shortName, upgrade.maxLevel, upgrade.maxLevelBarrier, upgrade.startCost, upgrade.incCost, sPermissions, sPluginFile);
 	}
 	if(iUnavailableCount > 0)
 	{
@@ -696,7 +696,7 @@ public Action Cmd_SetUpgradeLvl(int client, int args)
 	GetCmdArg(2, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG: There is no upgrade with name \"%s\".", sUpgrade);
@@ -709,8 +709,8 @@ public Action Cmd_SetUpgradeLvl(int client, int args)
 	
 	// Make sure we're not over the maxlevel
 	int iLevel = StringToInt(sLevel);
-	if(StrEqual(sLevel, "max", false) || iLevel > upgrade[UPGR_maxLevel])
-		iLevel = upgrade[UPGR_maxLevel];
+	if(StrEqual(sLevel, "max", false) || iLevel > upgrade.maxLevel)
+		iLevel = upgrade.maxLevel;
 	
 	if(iLevel < 0)
 	{
@@ -718,7 +718,7 @@ public Action Cmd_SetUpgradeLvl(int client, int args)
 		return Plugin_Handled;
 	}
 	
-	int iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade.index;
 	
 	char sTargetName[MAX_TARGET_LENGTH];
 	int iTargetList[MAXPLAYERS], iTargetCount;
@@ -762,17 +762,17 @@ public Action Cmd_SetUpgradeLvl(int client, int args)
 			}
 		}
 		
-		LogAction(client, iTargetList[i], "%L set %L level of upgrade %s from %d to %d at no charge.", client, iTargetList[i], upgrade[UPGR_name], iLastOldUpgradeLevel, GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex));
+		LogAction(client, iTargetList[i], "%L set %L level of upgrade %s from %d to %d at no charge.", client, iTargetList[i], upgrade.name, iLastOldUpgradeLevel, GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex));
 	}
 	
 	if(tn_is_ml)
 	{
-		LogAction(client, -1, "%L set level of upgrade %s to %d for %T (%d players).", client, upgrade[UPGR_name], iLevel, sTargetName, LANG_SERVER, iTargetCount);
-		ReplyToCommand(client, "SM:RPG setupgradelvl: Set level upgrade %s to %d for %t (%d players).", upgrade[UPGR_name], iLevel, sTargetName, iTargetCount);
+		LogAction(client, -1, "%L set level of upgrade %s to %d for %T (%d players).", client, upgrade.name, iLevel, sTargetName, LANG_SERVER, iTargetCount);
+		ReplyToCommand(client, "SM:RPG setupgradelvl: Set level upgrade %s to %d for %t (%d players).", upgrade.name, iLevel, sTargetName, iTargetCount);
 	}
 	else
 	{
-		ReplyToCommand(client, "SM:RPG setupgradelvl: %N now has %s level %d (previously level %d)", iTargetList[0], upgrade[UPGR_name], GetClientPurchasedUpgradeLevel(iTargetList[0], iIndex), iLastOldUpgradeLevel);
+		ReplyToCommand(client, "SM:RPG setupgradelvl: %N now has %s level %d (previously level %d)", iTargetList[0], upgrade.name, GetClientPurchasedUpgradeLevel(iTargetList[0], iIndex), iLastOldUpgradeLevel);
 	}
 	
 	return Plugin_Handled;
@@ -794,14 +794,14 @@ public Action Cmd_GiveUpgrade(int client, int args)
 	GetCmdArg(2, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG giveupgrade: There is no upgrade with name \"%s\".", sUpgrade);
 		return Plugin_Handled;
 	}
 	
-	int iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade.index;
 	
 	char sTargetName[MAX_TARGET_LENGTH];
 	int iTargetList[MAXPLAYERS], iTargetCount;
@@ -826,7 +826,7 @@ public Action Cmd_GiveUpgrade(int client, int args)
 	{
 		iLastOldUpgradeLevel = GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex);
 		
-		if(iLastOldUpgradeLevel >= upgrade[UPGR_maxLevel])
+		if(iLastOldUpgradeLevel >= upgrade.maxLevel)
 		{
 			iCountAlreadyMaxed++;
 			continue;
@@ -838,13 +838,13 @@ public Action Cmd_GiveUpgrade(int client, int args)
 			continue;
 		}
 		
-		LogAction(client, iTargetList[i], "%L gave %L a level of upgrade %s at no charge. It changed from level %d to %d.", client, iTargetList[i], upgrade[UPGR_name], iLastOldUpgradeLevel, GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex));
+		LogAction(client, iTargetList[i], "%L gave %L a level of upgrade %s at no charge. It changed from level %d to %d.", client, iTargetList[i], upgrade.name, iLastOldUpgradeLevel, GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex));
 	}
 	
 	if(tn_is_ml)
 	{
-		LogAction(client, -1, "%L gave a level of upgrade %s to %T (%d players).", client, upgrade[UPGR_name], sTargetName, LANG_SERVER, iTargetCount);
-		ReplyToCommand(client, "SM:RPG giveupgrade: Gave a level of upgrade %s to %t (%d players).", upgrade[UPGR_name], sTargetName, iTargetCount);
+		LogAction(client, -1, "%L gave a level of upgrade %s to %T (%d players).", client, upgrade.name, sTargetName, LANG_SERVER, iTargetCount);
+		ReplyToCommand(client, "SM:RPG giveupgrade: Gave a level of upgrade %s to %t (%d players).", upgrade.name, sTargetName, iTargetCount);
 		if(iCountAlreadyMaxed > 0)
 			ReplyToCommand(client, "SM:RPG giveupgrade: %d players already had it on max.", iCountAlreadyMaxed);
 		if(iFailedCount > 0)
@@ -861,11 +861,11 @@ public Action Cmd_GiveUpgrade(int client, int args)
 	else
 	{
 		if(iCountAlreadyMaxed > 0)
-			ReplyToCommand(client, "SM:RPG giveupgrade: %N has the maximum level for %s (level %d)", iTargetList[0], upgrade[UPGR_name], iLastOldUpgradeLevel);
+			ReplyToCommand(client, "SM:RPG giveupgrade: %N has the maximum level for %s (level %d)", iTargetList[0], upgrade.name, iLastOldUpgradeLevel);
 		else if(iFailedCount > 0)
-			ReplyToCommand(client, "SM:RPG giveupgrade: Tried to give %N a level for upgrade %s, but it refused to level up.", iTargetList[0], upgrade[UPGR_name]);
+			ReplyToCommand(client, "SM:RPG giveupgrade: Tried to give %N a level for upgrade %s, but it refused to level up.", iTargetList[0], upgrade.name);
 		else
-			ReplyToCommand(client, "SM:RPG giveupgrade: %N now has %s level %d (previously level %d)", iTargetList[0], upgrade[UPGR_name], GetClientPurchasedUpgradeLevel(iTargetList[0], iIndex), iLastOldUpgradeLevel);
+			ReplyToCommand(client, "SM:RPG giveupgrade: %N now has %s level %d (previously level %d)", iTargetList[0], upgrade.name, GetClientPurchasedUpgradeLevel(iTargetList[0], iIndex), iLastOldUpgradeLevel);
 	}
 	
 	return Plugin_Handled;
@@ -900,19 +900,19 @@ public Action Cmd_GiveAll(int client, int args)
 	}
 	
 	int iSize = GetUpgradeCount();
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	for(int i=0;i<iTargetCount;i++)
 	{
 		// Run through all upgrades
 		for(int u=0;u<iSize;u++)
 		{
 			GetUpgradeByIndex(u, upgrade);
-			if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+			if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 				continue;
 			
 			// TODO: Obey adminflags and bot restrictions!
-			SetClientPurchasedUpgradeLevel(iTargetList[i], u, upgrade[UPGR_maxLevel]);
-			SetClientSelectedUpgradeLevel(iTargetList[i], u, upgrade[UPGR_maxLevel]);
+			SetClientPurchasedUpgradeLevel(iTargetList[i], u, upgrade.maxLevel);
+			SetClientSelectedUpgradeLevel(iTargetList[i], u, upgrade.maxLevel);
 		}
 		
 		LogAction(client, iTargetList[i], "%L set all upgrades of %L to the maximal level at no charge.", client, iTargetList[i]);
@@ -947,7 +947,7 @@ public Action Cmd_TakeUpgrade(int client, int args)
 	GetCmdArg(2, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG takeupgrade: There is no upgrade with shortname \"%s\".", sUpgrade);
@@ -970,7 +970,7 @@ public Action Cmd_TakeUpgrade(int client, int args)
 		return Plugin_Handled;
 	}
 	
-	int iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade.index;
 	
 	int iLastOldUpgradeLevel;
 	int iCountDontOwn;
@@ -992,13 +992,13 @@ public Action Cmd_TakeUpgrade(int client, int args)
 			continue;
 		}
 		
-		LogAction(client, iTargetList[i], "%L took a level of upgrade %s from %L with no refund. Changed upgrade level from %d to %d.", client, upgrade[UPGR_name], iTargetList[i], iLastOldUpgradeLevel, GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex));
+		LogAction(client, iTargetList[i], "%L took a level of upgrade %s from %L with no refund. Changed upgrade level from %d to %d.", client, upgrade.name, iTargetList[i], iLastOldUpgradeLevel, GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex));
 	}
 	
 	if(tn_is_ml)
 	{
-		LogAction(client, -1, "%L took a level of upgrade %s from %T (%d players).", client, upgrade[UPGR_name], sTargetName, LANG_SERVER, iTargetCount);
-		ReplyToCommand(client, "SM:RPG takeupgrade: Took a level of upgrade %s from %t (%d players).", upgrade[UPGR_name], sTargetName, iTargetCount);
+		LogAction(client, -1, "%L took a level of upgrade %s from %T (%d players).", client, upgrade.name, sTargetName, LANG_SERVER, iTargetCount);
+		ReplyToCommand(client, "SM:RPG takeupgrade: Took a level of upgrade %s from %t (%d players).", upgrade.name, sTargetName, iTargetCount);
 		if(iCountDontOwn > 0)
 			ReplyToCommand(client, "SM:RPG takeupgrade: %d players didn't own the upgrade at all.", iCountDontOwn);
 		if(iFailedCount > 0)
@@ -1015,11 +1015,11 @@ public Action Cmd_TakeUpgrade(int client, int args)
 	else
 	{
 		if(iCountDontOwn > 0)
-			ReplyToCommand(client, "SM:RPG takeupgrade: %N doesn't have upgrade %s.", iTargetList[0], upgrade[UPGR_name]);
+			ReplyToCommand(client, "SM:RPG takeupgrade: %N doesn't have upgrade %s.", iTargetList[0], upgrade.name);
 		else if(iFailedCount > 0)
-			ReplyToCommand(client, "SM:RPG takeupgrade: Tried to take a level of upgrade %s from %N, but it refused to level down.", upgrade[UPGR_name], iTargetList[0]);
+			ReplyToCommand(client, "SM:RPG takeupgrade: Tried to take a level of upgrade %s from %N, but it refused to level down.", upgrade.name, iTargetList[0]);
 		else
-			ReplyToCommand(client, "SM:RPG takeupgrade: %N now has %s level %d (previously level %d)", iTargetList[0], upgrade[UPGR_name], GetClientPurchasedUpgradeLevel(iTargetList[0], iIndex), iLastOldUpgradeLevel);
+			ReplyToCommand(client, "SM:RPG takeupgrade: %N now has %s level %d (previously level %d)", iTargetList[0], upgrade.name, GetClientPurchasedUpgradeLevel(iTargetList[0], iIndex), iLastOldUpgradeLevel);
 	}
 	
 	return Plugin_Handled;
@@ -1041,7 +1041,7 @@ public Action Cmd_BuyUpgrade(int client, int args)
 	GetCmdArg(2, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG buyupgrade: There is no upgrade with shortname \"%s\".", sUpgrade);
@@ -1064,7 +1064,7 @@ public Action Cmd_BuyUpgrade(int client, int args)
 		return Plugin_Handled;
 	}
 	
-	int iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade.index;
 	
 	int iLastOldUpgradeLevel;
 	int iCountAlreadyMaxed;
@@ -1075,7 +1075,7 @@ public Action Cmd_BuyUpgrade(int client, int args)
 		iLastOldUpgradeLevel = GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex);
 		
 		// Already has the maximum level, don't need to buy another one.
-		if(iLastOldUpgradeLevel >= upgrade[UPGR_maxLevel])
+		if(iLastOldUpgradeLevel >= upgrade.maxLevel)
 		{
 			iCountAlreadyMaxed++;
 			continue;
@@ -1096,13 +1096,13 @@ public Action Cmd_BuyUpgrade(int client, int args)
 			continue;
 		}
 		
-		LogAction(client, iTargetList[i], "%L forced %L to buy a level of upgrade %s. The upgrade level changed from %d to %d", client, iTargetList[i], upgrade[UPGR_name], iLastOldUpgradeLevel, GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex));
+		LogAction(client, iTargetList[i], "%L forced %L to buy a level of upgrade %s. The upgrade level changed from %d to %d", client, iTargetList[i], upgrade.name, iLastOldUpgradeLevel, GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex));
 	}
 	
 	if(tn_is_ml)
 	{
-		LogAction(client, -1, "%L forced %T (%d players) to buy a level of upgrade %s.", client, sTargetName, LANG_SERVER, iTargetCount, upgrade[UPGR_name]);
-		ReplyToCommand(client, "SM:RPG buyupgrade: Made %t (%d players) buy a level of upgrade %s.", sTargetName, iTargetCount, upgrade[UPGR_name]);
+		LogAction(client, -1, "%L forced %T (%d players) to buy a level of upgrade %s.", client, sTargetName, LANG_SERVER, iTargetCount, upgrade.name);
+		ReplyToCommand(client, "SM:RPG buyupgrade: Made %t (%d players) buy a level of upgrade %s.", sTargetName, iTargetCount, upgrade.name);
 		if(iCountAlreadyMaxed > 0)
 			ReplyToCommand(client, "SM:RPG buyupgrade: %d players already had the upgrade at the maximal level.", iCountAlreadyMaxed);
 		if(iPoorCount > 0)
@@ -1129,13 +1129,13 @@ public Action Cmd_BuyUpgrade(int client, int args)
 	else
 	{
 		if(iCountAlreadyMaxed > 0)
-			ReplyToCommand(client, "SM:RPG buyupgrade: %N has the maximum level for %s (level %d).", iTargetList[0], upgrade[UPGR_name], iLastOldUpgradeLevel);
+			ReplyToCommand(client, "SM:RPG buyupgrade: %N has the maximum level for %s (level %d).", iTargetList[0], upgrade.name, iLastOldUpgradeLevel);
 		else if(iPoorCount > 0)
-			ReplyToCommand(client, "SM:RPG buyupgrade: %N doesn't have enough credits to purchase %s (%d/%d).", iTargetList[0], upgrade[UPGR_name], GetClientCredits(iTargetList[0]), GetUpgradeCost(iIndex, iLastOldUpgradeLevel));
+			ReplyToCommand(client, "SM:RPG buyupgrade: %N doesn't have enough credits to purchase %s (%d/%d).", iTargetList[0], upgrade.name, GetClientCredits(iTargetList[0]), GetUpgradeCost(iIndex, iLastOldUpgradeLevel));
 		else if(iFailedCount > 0)
-			ReplyToCommand(client, "SM:RPG buyupgrade: Tried to make %N buy a level of upgrade %s, but it refused to level up.", iTargetList[0], upgrade[UPGR_name]);
+			ReplyToCommand(client, "SM:RPG buyupgrade: Tried to make %N buy a level of upgrade %s, but it refused to level up.", iTargetList[0], upgrade.name);
 		else
-			ReplyToCommand(client, "SM:RPG buyupgrade: %N now has %s level %d (previously level %d).", iTargetList[0], upgrade[UPGR_name], GetClientPurchasedUpgradeLevel(iTargetList[0], iIndex), iLastOldUpgradeLevel);
+			ReplyToCommand(client, "SM:RPG buyupgrade: %N now has %s level %d (previously level %d).", iTargetList[0], upgrade.name, GetClientPurchasedUpgradeLevel(iTargetList[0], iIndex), iLastOldUpgradeLevel);
 	}
 	
 	return Plugin_Handled;
@@ -1157,7 +1157,7 @@ public Action Cmd_SellUpgrade(int client, int args)
 	GetCmdArg(2, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG sellupgrade: There is no upgrade with name \"%s\".", sUpgrade);
@@ -1180,7 +1180,7 @@ public Action Cmd_SellUpgrade(int client, int args)
 		return Plugin_Handled;
 	}
 	
-	int iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade.index;
 	
 	int iLastOldUpgradeLevel;
 	int iCountDontOwn;
@@ -1206,13 +1206,13 @@ public Action Cmd_SellUpgrade(int client, int args)
 		int iUpgradeCosts = GetUpgradeCost(iIndex, iLastOldUpgradeLevel);
 		SetClientCredits(iTargetList[i], GetClientCredits(iTargetList[i]) + iUpgradeCosts);
 		
-		LogAction(client, iTargetList[i], "%L forced %L to sell a level of upgrade %s with full refund of the costs. The upgrade level changed from %d to %d and he received %d credits.", client, iTargetList[i], upgrade[UPGR_name], iLastOldUpgradeLevel, GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex), iUpgradeCosts);
+		LogAction(client, iTargetList[i], "%L forced %L to sell a level of upgrade %s with full refund of the costs. The upgrade level changed from %d to %d and he received %d credits.", client, iTargetList[i], upgrade.name, iLastOldUpgradeLevel, GetClientPurchasedUpgradeLevel(iTargetList[i], iIndex), iUpgradeCosts);
 	}
 	
 	if(tn_is_ml)
 	{
-		LogAction(client, -1, "%L forced %T (%d players) to sell a level of upgrade %s with full refund.", client, sTargetName, LANG_SERVER, iTargetCount, upgrade[UPGR_name]);
-		ReplyToCommand(client, "SM:RPG sellupgrade: Forced %t (%d players) to sell a level of upgrade %s with full refund.", sTargetName, iTargetCount, upgrade[UPGR_name]);
+		LogAction(client, -1, "%L forced %T (%d players) to sell a level of upgrade %s with full refund.", client, sTargetName, LANG_SERVER, iTargetCount, upgrade.name);
+		ReplyToCommand(client, "SM:RPG sellupgrade: Forced %t (%d players) to sell a level of upgrade %s with full refund.", sTargetName, iTargetCount, upgrade.name);
 		if(iCountDontOwn > 0)
 			ReplyToCommand(client, "SM:RPG sellupgrade: %d players didn't own the upgrade at all.", iCountDontOwn);
 		if(iFailedCount > 0)
@@ -1229,11 +1229,11 @@ public Action Cmd_SellUpgrade(int client, int args)
 	else
 	{
 		if(iCountDontOwn > 0)
-			ReplyToCommand(client, "SM:RPG sellupgrade: %N doesn't have upgrade %s.", iTargetList[0], upgrade[UPGR_name]);
+			ReplyToCommand(client, "SM:RPG sellupgrade: %N doesn't have upgrade %s.", iTargetList[0], upgrade.name);
 		else if(iFailedCount > 0)
-			ReplyToCommand(client, "SM:RPG sellupgrade: Tried to force %N to sell a level of upgrade %s with full refund, but it refused to level down.", iTargetList[0], upgrade[UPGR_name]);
+			ReplyToCommand(client, "SM:RPG sellupgrade: Tried to force %N to sell a level of upgrade %s with full refund, but it refused to level down.", iTargetList[0], upgrade.name);
 		else
-			ReplyToCommand(client, "SM:RPG sellupgrade: %N sold one level of upgrade %s with full refund, is now on level %d (previously level %d) and received %d credits.", iTargetList[0], upgrade[UPGR_name], GetClientPurchasedUpgradeLevel(iTargetList[0], iIndex), iLastOldUpgradeLevel, GetUpgradeCost(iIndex, iLastOldUpgradeLevel));
+			ReplyToCommand(client, "SM:RPG sellupgrade: %N sold one level of upgrade %s with full refund, is now on level %d (previously level %d) and received %d credits.", iTargetList[0], upgrade.name, GetClientPurchasedUpgradeLevel(iTargetList[0], iIndex), iLastOldUpgradeLevel, GetUpgradeCost(iIndex, iLastOldUpgradeLevel));
 	}
 	
 	return Plugin_Handled;
@@ -1268,7 +1268,7 @@ public Action Cmd_SellAll(int client, int args)
 	}
 	
 	int iSize = GetUpgradeCount();
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	int iLastCreditsReturned;
 	for(int i=0;i<iTargetCount;i++)
 	{
@@ -1276,7 +1276,7 @@ public Action Cmd_SellAll(int client, int args)
 		for(int u=0;u<iSize;u++)
 		{
 			GetUpgradeByIndex(u, upgrade);
-			if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+			if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 				continue;
 			
 			while(GetClientPurchasedUpgradeLevel(iTargetList[i], u) > 0)
@@ -1377,14 +1377,14 @@ public Action Cmd_DBMassSell(int client, int args)
 	GetCmdArg(1, sUpgrade, sizeof(sUpgrade));
 	TrimString(sUpgrade);
 	StripQuotes(sUpgrade);
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	if(!GetUpgradeByShortname(sUpgrade, upgrade) || !IsValidUpgrade(upgrade))
 	{
 		ReplyToCommand(client, "SM:RPG: There is no upgrade with name \"%s\" loaded.", sUpgrade);
 		return Plugin_Handled;
 	}
 	
-	int iIndex = upgrade[UPGR_index];
+	int iIndex = upgrade.index;
 	
 	// Handle players ingame
 	int iOldLevel;
@@ -1411,7 +1411,7 @@ public Action Cmd_DBMassSell(int client, int args)
 	hData.WriteCell(iIndex);
 	
 	char sQuery[128];
-	Format(sQuery, sizeof(sQuery), "SELECT player_id, purchasedlevel FROM %s WHERE upgrade_id = %d AND purchasedlevel > 0", TBL_PLAYERUPGRADES, upgrade[UPGR_databaseId]);
+	Format(sQuery, sizeof(sQuery), "SELECT player_id, purchasedlevel FROM %s WHERE upgrade_id = %d AND purchasedlevel > 0", TBL_PLAYERUPGRADES, upgrade.databaseId);
 	g_hDatabase.Query(SQL_MassDeleteItem, sQuery, hData);
 	
 	return Plugin_Handled;
@@ -1497,7 +1497,7 @@ public void SQL_CheckDeletePlayer(Database db, DBResultSet results, const char[]
 		g_hDatabase.Query(SQL_DoNothing, sQuery);
 		
 		if(iTarget != -1)
-			g_iPlayerInfo[iTarget][PLR_dbId] = -1;
+			g_iPlayerInfo[iTarget].dbId = -1;
 		
 		char sName[64];
 		results.FetchString(1, sName, sizeof(sName));
@@ -1530,12 +1530,12 @@ public void SQL_MassDeleteItem(Database db, DBResultSet results, const char[] er
 	int iIndex = data.ReadCell();
 	delete data;
 	
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	GetUpgradeByIndex(iIndex, upgrade);
 	
 	if(results == null)
 	{
-		LogAction(client, -1, "%L tried to mass sell upgrade \"%s\", but the select query failed. It might have been reset on some players ingame though!", client, upgrade[UPGR_name]);
+		LogAction(client, -1, "%L tried to mass sell upgrade \"%s\", but the select query failed. It might have been reset on some players ingame though!", client, upgrade.name);
 		LogError("Error during mass deletion of item (%s)", error);
 		return;
 	}
@@ -1544,8 +1544,8 @@ public void SQL_MassDeleteItem(Database db, DBResultSet results, const char[] er
 	{
 		if(client == 0 || IsClientInGame(client))
 		{
-			LogAction(client, -1, "%L tried to mass sell upgrade \"%s\", but nobody has the upgrade purchased at any level.", client, upgrade[UPGR_name]);
-			ReplyToCommand(client, "SM:RPG db_mass_sell: Nobody has the Upgrade '%s' purchased at any level.", upgrade[UPGR_name]);
+			LogAction(client, -1, "%L tried to mass sell upgrade \"%s\", but nobody has the upgrade purchased at any level.", client, upgrade.name);
+			ReplyToCommand(client, "SM:RPG db_mass_sell: Nobody has the Upgrade '%s' purchased at any level.", upgrade.name);
 		}
 		return;
 	}
@@ -1573,13 +1573,13 @@ public void SQL_MassDeleteItem(Database db, DBResultSet results, const char[] er
 			iOldLevel = results.FetchInt(1);
 			if(iOldLevel < 0)
 			{
-				DebugMsg("Negative level for upgrade %s in database for player %d!", upgrade[UPGR_name], iPlayerID);
+				DebugMsg("Negative level for upgrade %s in database for player %d!", upgrade.name, iPlayerID);
 				iOldLevel = 0;
 			}
-			if(iOldLevel > upgrade[UPGR_maxLevel])
+			if(iOldLevel > upgrade.maxLevel)
 			{
-				DebugMsg("Upgrade level higher than max level of upgrade %s for player %d!", upgrade[UPGR_name], iPlayerID);
-				iOldLevel = upgrade[UPGR_maxLevel];
+				DebugMsg("Upgrade level higher than max level of upgrade %s for player %d!", upgrade.name, iPlayerID);
+				iOldLevel = upgrade.maxLevel;
 			}
 			
 			iAddCredits = 0;
@@ -1593,20 +1593,20 @@ public void SQL_MassDeleteItem(Database db, DBResultSet results, const char[] er
 		g_hDatabase.Execute(hTransaction, _, SQLTxn_LogFailure);
 		
 		// Reset all players to upgrade level 0
-		Format(sQuery, sizeof(sQuery), "UPDATE %s SET purchasedlevel = 0, selectedlevel = 0 WHERE upgrade_id = %d", TBL_PLAYERUPGRADES, upgrade[UPGR_databaseId]);
+		Format(sQuery, sizeof(sQuery), "UPDATE %s SET purchasedlevel = 0, selectedlevel = 0 WHERE upgrade_id = %d", TBL_PLAYERUPGRADES, upgrade.databaseId);
 		g_hDatabase.Query(SQL_DoNothing, sQuery);
 		
 		if(client == 0 || IsClientInGame(client))
 		{
-			LogAction(client, -1, "%L mass sold upgrade \"%s\" on all players with full costs refunded. %d players in the database have been refunded their credits.", client, upgrade[UPGR_name], results.RowCount);
-			ReplyToCommand(client, "SM:RPG db_mass_sell: All (%d) players in the database with Upgrade '%s' have been refunded their credits", results.RowCount, upgrade[UPGR_name]);
+			LogAction(client, -1, "%L mass sold upgrade \"%s\" on all players with full costs refunded. %d players in the database have been refunded their credits.", client, upgrade.name, results.RowCount);
+			ReplyToCommand(client, "SM:RPG db_mass_sell: All (%d) players in the database with Upgrade '%s' have been refunded their credits", results.RowCount, upgrade.name);
 		}
 	}
 	else
 	{
 		if(client == 0 || IsClientInGame(client))
 		{
-			LogAction(client, -1, "%L tried to mass sell upgrade \"%s\", but data saving is disabled (smrpg_save_data 0). It might have been reset on some players ingame though!", client, upgrade[UPGR_name]);
+			LogAction(client, -1, "%L tried to mass sell upgrade \"%s\", but data saving is disabled (smrpg_save_data 0). It might have been reset on some players ingame though!", client, upgrade.name);
 			ReplyToCommand(client, "SM:RPG db_mass_sell: Notice: smrpg_save_data is set to '0', command had no effect");
 		}
 	}
@@ -1694,7 +1694,7 @@ public void SQL_PrintUpgradeUsage(Database db, DBResultSet results, const char[]
 		return;
 	}
 
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	ReplySource oldSource = SetCmdReplySource(source);
 	while(results.MoreRows)
 	{

--- a/scripting/smrpg/smrpg_adminmenu.sp
+++ b/scripting/smrpg/smrpg_adminmenu.sp
@@ -479,7 +479,8 @@ void ShowPlayerUpgradeManageMenu(int client)
 	}
 	
 	int iSize = GetUpgradeCount();
-	int upgrade[InternalUpgradeInfo], iCurrentLevel;
+	InternalUpgradeInfo upgrade;
+	int iCurrentLevel;
 	char sTranslatedName[MAX_UPGRADE_NAME_LENGTH], sLine[128], sIndex[8], sPermissions[30], sTeamlock[32];
 	for(int i=0;i<iSize;i++)
 	{
@@ -487,18 +488,18 @@ void ShowPlayerUpgradeManageMenu(int client)
 		GetUpgradeByIndex(i, upgrade);
 		
 		// Don't show disabled items in the menu.
-		if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+		if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 			continue;
 		
-		GetUpgradeTranslatedName(client, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+		GetUpgradeTranslatedName(client, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 		
 		sPermissions[0] = 0;
 		sTeamlock[0] = 0;
 		
 		// Print the required adminflags in a readable way
-		if(upgrade[UPGR_adminFlag] > 0)
+		if(upgrade.adminFlag > 0)
 		{
-			GetAdminFlagStringFromBits(upgrade[UPGR_adminFlag], sPermissions, sizeof(sPermissions));
+			GetAdminFlagStringFromBits(upgrade.adminFlag, sPermissions, sizeof(sPermissions));
 			Format(sPermissions, sizeof(sPermissions), "%T", "Adminflags hint", client, sPermissions);
 		}
 		
@@ -506,24 +507,24 @@ void ShowPlayerUpgradeManageMenu(int client)
 		if(!HasAccessToUpgrade(g_iCurrentMenuTarget[client], upgrade))
 			Format(sPermissions, sizeof(sPermissions), "%s %T", sPermissions, "Adminflags Admin Denied Warning", client);
 		// Or if there are some permission restrictions specified, show the player is able to use it.
-		else if(upgrade[UPGR_adminFlag] > 0)
+		else if(upgrade.adminFlag > 0)
 			Format(sPermissions, sizeof(sPermissions), "%s %T", sPermissions, "Adminflags Admin Inform OK", client);
 		
 		// Print the required team
-		if(upgrade[UPGR_teamlock] > 1 && upgrade[UPGR_teamlock] < GetTeamCount())
+		if(upgrade.teamlock > 1 && upgrade.teamlock < GetTeamCount())
 		{
-			GetTeamName(upgrade[UPGR_teamlock], sTeamlock, sizeof(sTeamlock));
+			GetTeamName(upgrade.teamlock, sTeamlock, sizeof(sTeamlock));
 			Format(sTeamlock, sizeof(sTeamlock), "%T", "Teamlock hint", client, sTeamlock);
 		}
 		
 		IntToString(i, sIndex, sizeof(sIndex));
-		if(iCurrentLevel >= upgrade[UPGR_maxLevel])
+		if(iCurrentLevel >= upgrade.maxLevel)
 		{
-			Format(sLine, sizeof(sLine), "%T", "Admin player upgrades list item maxed", client, sTranslatedName, iCurrentLevel, upgrade[UPGR_maxLevel], sPermissions, sTeamlock);
+			Format(sLine, sizeof(sLine), "%T", "Admin player upgrades list item maxed", client, sTranslatedName, iCurrentLevel, upgrade.maxLevel, sPermissions, sTeamlock);
 		}
 		else
 		{
-			Format(sLine, sizeof(sLine), "%T", "Admin player upgrades list item", client, sTranslatedName, iCurrentLevel, upgrade[UPGR_maxLevel], sPermissions, sTeamlock);
+			Format(sLine, sizeof(sLine), "%T", "Admin player upgrades list item", client, sTranslatedName, iCurrentLevel, upgrade.maxLevel, sPermissions, sTeamlock);
 		}
 		
 		hMenu.AddItem(sIndex, sLine);
@@ -601,15 +602,15 @@ public int Menu_HandlePlayerGiveAllConfirm(Menu menu, MenuAction action, int par
 		}
 		
 		int iSize = GetUpgradeCount();
-		int upgrade[InternalUpgradeInfo];
+		InternalUpgradeInfo upgrade;
 		for(int i=0;i<iSize;i++)
 		{
 			GetUpgradeByIndex(i, upgrade);
-			if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+			if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 				continue;
 			
-			SetClientPurchasedUpgradeLevel(g_iCurrentMenuTarget[param1], i, upgrade[UPGR_maxLevel]);
-			SetClientSelectedUpgradeLevel(g_iCurrentMenuTarget[param1], i, upgrade[UPGR_maxLevel]);
+			SetClientPurchasedUpgradeLevel(g_iCurrentMenuTarget[param1], i, upgrade.maxLevel);
+			SetClientSelectedUpgradeLevel(g_iCurrentMenuTarget[param1], i, upgrade.maxLevel);
 		}
 		
 		LogAction(param1, g_iCurrentMenuTarget[param1], "%L set all upgrades of %L to the maximal level at no charge.", param1, g_iCurrentMenuTarget[param1]);
@@ -636,11 +637,11 @@ public int Menu_HandlePlayerGiveAllConfirm(Menu menu, MenuAction action, int par
 void ShowPlayerUpgradeLevelMenu(int client)
 {
 	int iItemIndex = g_iCurrentUpgradeTarget[client];
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	GetUpgradeByIndex(iItemIndex, upgrade);
 	
 	// Bad upgrade?
-	if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+	if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 	{
 		g_iCurrentUpgradeTarget[client] = -1;
 		ShowPlayerUpgradeManageMenu(client);
@@ -648,11 +649,11 @@ void ShowPlayerUpgradeLevelMenu(int client)
 	}
 	
 	char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-	GetUpgradeTranslatedName(client, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+	GetUpgradeTranslatedName(client, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 	
 	Menu hMenu = new Menu(Menu_HandlePlayerUpgradeLevelChange);
 	hMenu.ExitBackButton = true;
-	hMenu.SetTitle("%T\n%T", "Change player upgrade level", client, g_iCurrentMenuTarget[client], "Current player upgrade level", client, sTranslatedName, GetClientPurchasedUpgradeLevel(g_iCurrentMenuTarget[client], iItemIndex), upgrade[UPGR_maxLevel]);
+	hMenu.SetTitle("%T\n%T", "Change player upgrade level", client, g_iCurrentMenuTarget[client], "Current player upgrade level", client, sTranslatedName, GetClientPurchasedUpgradeLevel(g_iCurrentMenuTarget[client], iItemIndex), upgrade.maxLevel);
 	
 	char sBuffer[256];
 	if (CheckCommandAccess(client, "smrpg_takeupgrade", ADMFLAG_ROOT)
@@ -702,12 +703,12 @@ public int Menu_HandlePlayerUpgradeLevelChange(Menu menu, MenuAction action, int
 		char sInfo[32];
 		menu.GetItem(param2, sInfo, sizeof(sInfo));
 		
-		int upgrade[InternalUpgradeInfo];
+		InternalUpgradeInfo upgrade;
 		int iItemIndex = g_iCurrentUpgradeTarget[param1];
 		GetUpgradeByIndex(iItemIndex, upgrade);
 		
 		// Bad upgrade?
-		if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+		if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 		{
 			g_iCurrentUpgradeTarget[param1] = -1;
 			ShowPlayerUpgradeManageMenu(param1);
@@ -740,11 +741,11 @@ public int Menu_HandlePlayerUpgradeLevelChange(Menu menu, MenuAction action, int
 void ShowPlayerUpgradeLevelRemoveMenu(int client)
 {
 	int iItemIndex = g_iCurrentUpgradeTarget[client];
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	GetUpgradeByIndex(iItemIndex, upgrade);
 	
 	// Bad upgrade?
-	if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+	if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 	{
 		g_iCurrentUpgradeTarget[client] = -1;
 		ShowPlayerUpgradeManageMenu(client);
@@ -752,7 +753,7 @@ void ShowPlayerUpgradeLevelRemoveMenu(int client)
 	}
 	
 	char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-	GetUpgradeTranslatedName(client, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+	GetUpgradeTranslatedName(client, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 	
 	Menu hMenu = new Menu(Menu_HandlePlayerUpgradeLevelRemove);
 	hMenu.ExitBackButton = true;
@@ -762,7 +763,7 @@ void ShowPlayerUpgradeLevelRemoveMenu(int client)
 		Format(sBuffer, sizeof(sBuffer), "%T", "Reset player upgrade level 0", client);
 	else
 		Format(sBuffer, sizeof(sBuffer), "%T", "Remove player upgrade level", client);
-	hMenu.SetTitle("%T\n%s\n%T", "Change player upgrade level", client, g_iCurrentMenuTarget[client], sBuffer, "Current player upgrade level", client, sTranslatedName, GetClientPurchasedUpgradeLevel(g_iCurrentMenuTarget[client], iItemIndex), upgrade[UPGR_maxLevel]);
+	hMenu.SetTitle("%T\n%s\n%T", "Change player upgrade level", client, g_iCurrentMenuTarget[client], sBuffer, "Current player upgrade level", client, sTranslatedName, GetClientPurchasedUpgradeLevel(g_iCurrentMenuTarget[client], iItemIndex), upgrade.maxLevel);
 	
 	
 	if (CheckCommandAccess(client, "smrpg_setupgradelvl", ADMFLAG_ROOT))
@@ -808,12 +809,12 @@ public int Menu_HandlePlayerUpgradeLevelRemove(Menu menu, MenuAction action, int
 		char sInfo[32];
 		menu.GetItem(param2, sInfo, sizeof(sInfo));
 		
-		int upgrade[InternalUpgradeInfo];
+		InternalUpgradeInfo upgrade;
 		int iUpgradeIndex = g_iCurrentUpgradeTarget[param1];
 		GetUpgradeByIndex(iUpgradeIndex, upgrade);
 		
 		// Bad upgrade?
-		if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+		if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 		{
 			g_iCurrentUpgradeTarget[param1] = -1;
 			ShowPlayerUpgradeManageMenu(param1);
@@ -835,7 +836,7 @@ public int Menu_HandlePlayerUpgradeLevelRemove(Menu menu, MenuAction action, int
 					iCreditsReturned += GetUpgradeCost(iUpgradeIndex, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex)+1);
 					SetClientCredits(iTarget, GetClientCredits(iTarget) + GetUpgradeCost(iUpgradeIndex, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex)+1));
 				}
-				LogAction(param1, iTarget, "%L reset upgrade %s of %L with full refund of all upgrade costs. Upgrade level changed from %d to %d and player earned %d credits.", param1, upgrade[UPGR_name], iTarget, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex), iCreditsReturned);
+				LogAction(param1, iTarget, "%L reset upgrade %s of %L with full refund of all upgrade costs. Upgrade level changed from %d to %d and player earned %d credits.", param1, upgrade.name, iTarget, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex), iCreditsReturned);
 			}
 			else if(StrEqual(sInfo, "forcesell"))
 			{
@@ -844,18 +845,18 @@ public int Menu_HandlePlayerUpgradeLevelRemove(Menu menu, MenuAction action, int
 					iCreditsReturned += GetUpgradeSale(iUpgradeIndex, iOldLevel);
 					iOldLevel--;
 				}
-				LogAction(param1, iTarget, "%L forced %L to sell all levels of upgrade %s. Upgrade level changed from %d to %d and player earned %d credits.", param1, iTarget, upgrade[UPGR_name], iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex), iCreditsReturned);
+				LogAction(param1, iTarget, "%L forced %L to sell all levels of upgrade %s. Upgrade level changed from %d to %d and player earned %d credits.", param1, iTarget, upgrade.name, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex), iCreditsReturned);
 			}
 			else if(StrEqual(sInfo, "norefund"))
 			{
 				while(TakeClientUpgrade(iTarget, iUpgradeIndex))
 				{
 				}
-				LogAction(param1, iTarget, "%L reset upgrade %s of %L with no refund. Upgrade level changed from %d to %d.", param1, upgrade[UPGR_name], iTarget, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex));
+				LogAction(param1, iTarget, "%L reset upgrade %s of %L with no refund. Upgrade level changed from %d to %d.", param1, upgrade.name, iTarget, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex));
 			}
 
 			char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-			GetUpgradeTranslatedName(param1, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+			GetUpgradeTranslatedName(param1, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 			Client_PrintToChat(param1, false, "{OG}SM:RPG{N} > {G}%T", "Admin reset player upgrades notification", param1, iTarget, sTranslatedName, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex), iCreditsReturned);
 		}
 		else if (g_iClientUpgradeChangeMode[param1] == UpgradeChange_Remove)
@@ -867,14 +868,14 @@ public int Menu_HandlePlayerUpgradeLevelRemove(Menu menu, MenuAction action, int
 					// Full refund
 					int iCosts = GetUpgradeCost(iUpgradeIndex, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex)+1);
 					SetClientCredits(iTarget, GetClientCredits(iTarget) + iCosts);
-					LogAction(param1, iTarget, "%L took one level of upgrade %s from %L with full refund of the costs. Upgrade level changed from %d to %d and player got %d credits.", param1, upgrade[UPGR_name], iTarget, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex), iCosts);
+					LogAction(param1, iTarget, "%L took one level of upgrade %s from %L with full refund of the costs. Upgrade level changed from %d to %d and player got %d credits.", param1, upgrade.name, iTarget, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex), iCosts);
 				}
 			}
 			else if(StrEqual(sInfo, "forcesell"))
 			{
 				if(SellClientUpgrade(iTarget, iUpgradeIndex))
 				{
-					LogAction(param1, iTarget, "%L forced %L to sell one level of upgrade %s. Upgrade level changed from %d to %d and player got %d credits..", param1, iTarget, upgrade[UPGR_name], iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex), GetUpgradeSale(iUpgradeIndex, iOldLevel));
+					LogAction(param1, iTarget, "%L forced %L to sell one level of upgrade %s. Upgrade level changed from %d to %d and player got %d credits..", param1, iTarget, upgrade.name, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex), GetUpgradeSale(iUpgradeIndex, iOldLevel));
 				}
 			}
 			else if(StrEqual(sInfo, "norefund"))
@@ -884,7 +885,7 @@ public int Menu_HandlePlayerUpgradeLevelRemove(Menu menu, MenuAction action, int
 					// Full refund
 					int iCosts = GetUpgradeCost(iUpgradeIndex, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex)+1);
 					SetClientCredits(iTarget, GetClientCredits(iTarget) + iCosts);
-					LogAction(param1, iTarget, "%L took one level of upgrade %s from %L with full refund of the costs. Upgrade level changed from %d to %d and player got %d credits.", param1, upgrade[UPGR_name], iTarget, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex), iCosts);
+					LogAction(param1, iTarget, "%L took one level of upgrade %s from %L with full refund of the costs. Upgrade level changed from %d to %d and player got %d credits.", param1, upgrade.name, iTarget, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex), iCosts);
 				}
 			}
 		}
@@ -896,11 +897,11 @@ public int Menu_HandlePlayerUpgradeLevelRemove(Menu menu, MenuAction action, int
 void ShowPlayerUpgradeLevelAddMenu(int client)
 {
 	int iItemIndex = g_iCurrentUpgradeTarget[client];
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	GetUpgradeByIndex(iItemIndex, upgrade);
 	
 	// Bad upgrade?
-	if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+	if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 	{
 		g_iCurrentUpgradeTarget[client] = -1;
 		ShowPlayerUpgradeManageMenu(client);
@@ -908,7 +909,7 @@ void ShowPlayerUpgradeLevelAddMenu(int client)
 	}
 	
 	char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-	GetUpgradeTranslatedName(client, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+	GetUpgradeTranslatedName(client, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 	
 	Menu hMenu = new Menu(Menu_HandlePlayerUpgradeLevelAdd);
 	hMenu.ExitBackButton = true;
@@ -918,7 +919,7 @@ void ShowPlayerUpgradeLevelAddMenu(int client)
 		Format(sBuffer, sizeof(sBuffer), "%T", "Add player upgrade level", client);
 	else
 		Format(sBuffer, sizeof(sBuffer), "%T", "Set player upgrade level to max", client);
-	hMenu.SetTitle("%T\n%s\n%T", "Change player upgrade level", client, g_iCurrentMenuTarget[client], sBuffer, "Current player upgrade level", client, sTranslatedName, GetClientPurchasedUpgradeLevel(g_iCurrentMenuTarget[client], iItemIndex), upgrade[UPGR_maxLevel]);
+	hMenu.SetTitle("%T\n%s\n%T", "Change player upgrade level", client, g_iCurrentMenuTarget[client], sBuffer, "Current player upgrade level", client, sTranslatedName, GetClientPurchasedUpgradeLevel(g_iCurrentMenuTarget[client], iItemIndex), upgrade.maxLevel);
 	
 	
 	if (CheckCommandAccess(client, "smrpg_giveupgrade", ADMFLAG_ROOT) || CheckCommandAccess(client, "smrpg_setupgradelvl", ADMFLAG_ROOT))
@@ -959,12 +960,12 @@ public int Menu_HandlePlayerUpgradeLevelAdd(Menu menu, MenuAction action, int pa
 		char sInfo[32];
 		menu.GetItem(param2, sInfo, sizeof(sInfo));
 		
-		int upgrade[InternalUpgradeInfo];
+		InternalUpgradeInfo upgrade;
 		int iUpgradeIndex = g_iCurrentUpgradeTarget[param1];
 		GetUpgradeByIndex(iUpgradeIndex, upgrade);
 		
 		// Bad upgrade?
-		if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+		if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 		{
 			g_iCurrentUpgradeTarget[param1] = -1;
 			ShowPlayerUpgradeManageMenu(param1);
@@ -982,14 +983,14 @@ public int Menu_HandlePlayerUpgradeLevelAdd(Menu menu, MenuAction action, int pa
 				while(GiveClientUpgrade(iTarget, iUpgradeIndex))
 				{
 				}
-				LogAction(param1, iTarget, "%L gave %L the maximal level of upgrade %s at no charge. Upgrade level changed from %d to %d.", param1, iTarget, upgrade[UPGR_name], iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex));
+				LogAction(param1, iTarget, "%L gave %L the maximal level of upgrade %s at no charge. Upgrade level changed from %d to %d.", param1, iTarget, upgrade.name, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex));
 			}
 			else if(StrEqual(sInfo, "forcebuy"))
 			{
 				while(BuyClientUpgrade(iTarget, iUpgradeIndex))
 				{
 				}
-				LogAction(param1, iTarget, "%L forced %L to buy as many levels of upgrade %s he can afford. Upgrade level changed from %d to %d and player earned %d credits.", param1, iTarget, upgrade[UPGR_name], iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex));
+				LogAction(param1, iTarget, "%L forced %L to buy as many levels of upgrade %s he can afford. Upgrade level changed from %d to %d and player earned %d credits.", param1, iTarget, upgrade.name, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex));
 			}
 		}
 		else if (g_iClientUpgradeChangeMode[param1] == UpgradeChange_Add)
@@ -997,7 +998,7 @@ public int Menu_HandlePlayerUpgradeLevelAdd(Menu menu, MenuAction action, int pa
 			if(StrEqual(sInfo, "givefree"))
 			{
 				GiveClientUpgrade(iTarget, iUpgradeIndex);
-				LogAction(param1, iTarget, "%L gave %L one level of upgrade %s at no charge. Upgrade level changed from %d to %d.", param1, iTarget, upgrade[UPGR_name], iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex));
+				LogAction(param1, iTarget, "%L gave %L one level of upgrade %s at no charge. Upgrade level changed from %d to %d.", param1, iTarget, upgrade.name, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex));
 			}
 			else if(StrEqual(sInfo, "forcebuy"))
 			{
@@ -1005,14 +1006,14 @@ public int Menu_HandlePlayerUpgradeLevelAdd(Menu menu, MenuAction action, int pa
 				if(iCost > GetClientCredits(iTarget))
 				{
 					char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-					GetUpgradeTranslatedName(param1, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+					GetUpgradeTranslatedName(param1, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 
 					Client_PrintToChat(param1, false, "{OG}SM:RPG{N} > {G}%T", "Admin force buy insufficient funds", param1, iTarget, sTranslatedName, GetClientCredits(iTarget), iCost);
 				}
 				else
 				{
 					BuyClientUpgrade(iTarget, iUpgradeIndex);
-					LogAction(param1, iTarget, "%L forced %L to buy one level of upgrade %s. Upgrade level changed from %d to %d.", param1, iTarget, upgrade[UPGR_name], iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex));
+					LogAction(param1, iTarget, "%L forced %L to buy one level of upgrade %s. Upgrade level changed from %d to %d.", param1, iTarget, upgrade.name, iOldLevel, GetClientPurchasedUpgradeLevel(iTarget, iUpgradeIndex));
 				}
 			}
 		}
@@ -1054,7 +1055,7 @@ void ShowUpgradeListMenu(int client)
 	hMenu.SetTitle("SM:RPG > %T", "Manage upgrades", client);
 	
 	int iSize = GetUpgradeCount();
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	char sTranslatedName[MAX_UPGRADE_NAME_LENGTH], sIndex[8];
 	for(int i=0;i<iSize;i++)
 	{
@@ -1064,7 +1065,7 @@ void ShowUpgradeListMenu(int client)
 		if(!IsValidUpgrade(upgrade))
 			continue;
 		
-		GetUpgradeTranslatedName(client, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+		GetUpgradeTranslatedName(client, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 		
 		IntToString(i, sIndex, sizeof(sIndex));
 		hMenu.AddItem(sIndex, sTranslatedName);
@@ -1104,7 +1105,7 @@ public int Menu_HandleSelectUpgrade(Menu menu, MenuAction action, int param1, in
 
 void ShowUpgradeManageMenu(int client)
 {
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	int iItemIndex = g_iCurrentUpgradeTarget[client];
 	GetUpgradeByIndex(iItemIndex, upgrade);
 	
@@ -1117,14 +1118,14 @@ void ShowUpgradeManageMenu(int client)
 	}
 	
 	char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-	GetUpgradeTranslatedName(client, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+	GetUpgradeTranslatedName(client, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 	
 	Menu hMenu = new Menu(Menu_HandleUpgradeDetails);
 	hMenu.ExitBackButton = true;
-	hMenu.SetTitle("%T > %s\n%T", "Manage upgrades", client, sTranslatedName, "Upgrade short name", client, upgrade[UPGR_shortName]);
+	hMenu.SetTitle("%T > %s\n%T", "Manage upgrades", client, sTranslatedName, "Upgrade short name", client, upgrade.shortName);
 	
 	char sBuffer[256];
-	if(upgrade[UPGR_enabled])
+	if(upgrade.enabled)
 		Format(sBuffer, sizeof(sBuffer), "%T", "Admin disable upgrade", client);
 	else
 		Format(sBuffer, sizeof(sBuffer), "%T", "Admin enable upgrade", client);
@@ -1132,36 +1133,36 @@ void ShowUpgradeManageMenu(int client)
 	
 	if(!g_hCVIgnoreLevelBarrier.BoolValue)
 	{
-		Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info maxlevel barrier", client, upgrade[UPGR_maxLevelBarrier]);
+		Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info maxlevel barrier", client, upgrade.maxLevelBarrier);
 		hMenu.AddItem("", sBuffer, ITEMDRAW_DISABLED);
 	}
 	
-	Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info maxlevel", client, upgrade[UPGR_maxLevel]);
+	Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info maxlevel", client, upgrade.maxLevel);
 	hMenu.AddItem("maxlevel", sBuffer);
 	
-	Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info cost", client, upgrade[UPGR_startCost]);
+	Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info cost", client, upgrade.startCost);
 	hMenu.AddItem("cost", sBuffer);
 	
-	Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info increase cost", client, upgrade[UPGR_incCost]);
+	Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info increase cost", client, upgrade.incCost);
 	hMenu.AddItem("icost", sBuffer);
 	
 	char sTeamlock[128] = "None";
-	if(upgrade[UPGR_teamlock] >= 1 && upgrade[UPGR_teamlock] < GetTeamCount())
+	if(upgrade.teamlock >= 1 && upgrade.teamlock < GetTeamCount())
 	{
-		GetTeamName(upgrade[UPGR_teamlock], sTeamlock, sizeof(sTeamlock));
+		GetTeamName(upgrade.teamlock, sTeamlock, sizeof(sTeamlock));
 	}
 	Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info teamlock", client, sTeamlock);
 	hMenu.AddItem("teamlock", sBuffer);
 	
-	if(upgrade[UPGR_visualsConvar] != null)
+	if(upgrade.visualsConvar != null)
 	{
-		Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info visual effects", client, upgrade[UPGR_enableVisuals]?"On":"Off");
+		Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info visual effects", client, upgrade.enableVisuals?"On":"Off");
 		hMenu.AddItem("visuals", sBuffer);
 	}
 	
-	if(upgrade[UPGR_soundsConvar] != null)
+	if(upgrade.soundsConvar != null)
 	{
-		Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info sound effects", client, upgrade[UPGR_enableSounds]?"On":"Off");
+		Format(sBuffer, sizeof(sBuffer), "%T", "Admin upgrade info sound effects", client, upgrade.enableSounds?"On":"Off");
 		hMenu.AddItem("sounds", sBuffer);
 	}
 	
@@ -1184,7 +1185,7 @@ public int Menu_HandleUpgradeDetails(Menu menu, MenuAction action, int param1, i
 	}
 	else if(action == MenuAction_Select)
 	{
-		int upgrade[InternalUpgradeInfo];
+		InternalUpgradeInfo upgrade;
 		GetUpgradeByIndex(g_iCurrentUpgradeTarget[param1], upgrade);
 	
 		// Bad upgrade?
@@ -1200,15 +1201,15 @@ public int Menu_HandleUpgradeDetails(Menu menu, MenuAction action, int param1, i
 		
 		if(StrEqual(sInfo, "enable"))
 		{
-			if(upgrade[UPGR_enabled])
+			if(upgrade.enabled)
 			{
-				upgrade[UPGR_enableConvar].SetBool(false);
-				LogAction(param1, -1, "%L disabled upgrade %s temporarily.", param1, upgrade[UPGR_name]);
+				upgrade.enableConvar.SetBool(false);
+				LogAction(param1, -1, "%L disabled upgrade %s temporarily.", param1, upgrade.name);
 			}
 			else
 			{
-				upgrade[UPGR_enableConvar].SetBool(true);
-				LogAction(param1, -1, "%L enabled upgrade %s temporarily.", param1, upgrade[UPGR_name]);
+				upgrade.enableConvar.SetBool(true);
+				LogAction(param1, -1, "%L enabled upgrade %s temporarily.", param1, upgrade.name);
 			}
 			ShowUpgradeManageMenu(param1);
 		}
@@ -1226,7 +1227,7 @@ public int Menu_HandleUpgradeDetails(Menu menu, MenuAction action, int param1, i
 		}
 		else if(StrEqual(sInfo, "teamlock"))
 		{
-			int iTeamlock = upgrade[UPGR_teamlock];
+			int iTeamlock = upgrade.teamlock;
 			iTeamlock++;
 			if(iTeamlock <= 1)
 				iTeamlock = 2; // Skip the spectator team..
@@ -1238,35 +1239,35 @@ public int Menu_HandleUpgradeDetails(Menu menu, MenuAction action, int param1, i
 			if(iTeamlock > 1)
 				GetTeamName(iTeamlock, sTeam, sizeof(sTeam));
 			
-			upgrade[UPGR_teamlockConvar].SetInt(iTeamlock);
-			LogAction(param1, -1, "%L toggled the teamlock on upgrade %s temporarily to restrict to team \"%s\".", param1, upgrade[UPGR_name], sTeam);
+			upgrade.teamlockConvar.SetInt(iTeamlock);
+			LogAction(param1, -1, "%L toggled the teamlock on upgrade %s temporarily to restrict to team \"%s\".", param1, upgrade.name, sTeam);
 			ShowUpgradeManageMenu(param1);
 		}
 		else if(StrEqual(sInfo, "visuals"))
 		{
-			if(upgrade[UPGR_enableVisuals])
+			if(upgrade.enableVisuals)
 			{
-				upgrade[UPGR_visualsConvar].SetBool(false);
-				LogAction(param1, -1, "%L disabled upgrade %s's visual effects temporarily.", param1, upgrade[UPGR_name]);
+				upgrade.visualsConvar.SetBool(false);
+				LogAction(param1, -1, "%L disabled upgrade %s's visual effects temporarily.", param1, upgrade.name);
 			}
 			else
 			{
-				upgrade[UPGR_visualsConvar].SetBool(true);
-				LogAction(param1, -1, "%L enabled upgrade %s's visual effects temporarily.", param1, upgrade[UPGR_name]);
+				upgrade.visualsConvar.SetBool(true);
+				LogAction(param1, -1, "%L enabled upgrade %s's visual effects temporarily.", param1, upgrade.name);
 			}
 			ShowUpgradeManageMenu(param1);
 		}
 		else if(StrEqual(sInfo, "sounds"))
 		{
-			if(upgrade[UPGR_enableSounds])
+			if(upgrade.enableSounds)
 			{
-				upgrade[UPGR_soundsConvar].SetBool(false);
-				LogAction(param1, -1, "%L disabled upgrade %s's sound effects temporarily.", param1, upgrade[UPGR_name]);
+				upgrade.soundsConvar.SetBool(false);
+				LogAction(param1, -1, "%L disabled upgrade %s's sound effects temporarily.", param1, upgrade.name);
 			}
 			else
 			{
-				upgrade[UPGR_soundsConvar].SetBool(true);
-				LogAction(param1, -1, "%L enabled upgrade %s's sound effects temporarily.", param1, upgrade[UPGR_name]);
+				upgrade.soundsConvar.SetBool(true);
+				LogAction(param1, -1, "%L enabled upgrade %s's sound effects temporarily.", param1, upgrade.name);
 			}
 			ShowUpgradeManageMenu(param1);
 		}
@@ -1275,7 +1276,7 @@ public int Menu_HandleUpgradeDetails(Menu menu, MenuAction action, int param1, i
 
 void ShowUpgradePropertyChangeMenu(int client, ChangeUpgradeProperty prop)
 {
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	int iItemIndex = g_iCurrentUpgradeTarget[client];
 	GetUpgradeByIndex(iItemIndex, upgrade);
 	
@@ -1289,26 +1290,26 @@ void ShowUpgradePropertyChangeMenu(int client, ChangeUpgradeProperty prop)
 	}
 	
 	char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-	GetUpgradeTranslatedName(client, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+	GetUpgradeTranslatedName(client, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 	
 	Menu hMenu = new Menu(Menu_HandlePropertyChange);
 	hMenu.ExitBackButton = true;
 	
 	char sBuffer[512];
-	Format(sBuffer, sizeof(sBuffer), "%T > %s\n%T\n", "Manage upgrades", client, sTranslatedName, "Upgrade short name", client, upgrade[UPGR_shortName]);
+	Format(sBuffer, sizeof(sBuffer), "%T > %s\n%T\n", "Manage upgrades", client, sTranslatedName, "Upgrade short name", client, upgrade.shortName);
 	switch(prop)
 	{
 		case ChangeProp_Maxlevel:
 		{
-			Format(sBuffer, sizeof(sBuffer), "%s%T", sBuffer, "Admin upgrades change maxlevel", client, upgrade[UPGR_maxLevel]);
+			Format(sBuffer, sizeof(sBuffer), "%s%T", sBuffer, "Admin upgrades change maxlevel", client, upgrade.maxLevel);
 		}
 		case ChangeProp_Cost:
 		{
-			Format(sBuffer, sizeof(sBuffer), "%s%T", sBuffer, "Admin upgrades change start cost", client, upgrade[UPGR_startCost]);
+			Format(sBuffer, sizeof(sBuffer), "%s%T", sBuffer, "Admin upgrades change start cost", client, upgrade.startCost);
 		}
 		case ChangeProp_Icost:
 		{
-			Format(sBuffer, sizeof(sBuffer), "%s%T", sBuffer, "Admin upgrades change increasing cost", client, upgrade[UPGR_incCost]);
+			Format(sBuffer, sizeof(sBuffer), "%s%T", sBuffer, "Admin upgrades change increasing cost", client, upgrade.incCost);
 		}
 	}
 	
@@ -1345,7 +1346,7 @@ public int Menu_HandlePropertyChange(Menu menu, MenuAction action, int param1, i
 	}
 	else if(action == MenuAction_Select)
 	{
-		int upgrade[InternalUpgradeInfo];
+		InternalUpgradeInfo upgrade;
 		GetUpgradeByIndex(g_iCurrentUpgradeTarget[param1], upgrade);
 	
 		// Bad upgrade?
@@ -1365,30 +1366,30 @@ public int Menu_HandlePropertyChange(Menu menu, MenuAction action, int param1, i
 		{
 			case ChangeProp_Maxlevel:
 			{
-				int iValue = upgrade[UPGR_maxLevel] + iChange;
-				int iMaxLevelBarrier = upgrade[UPGR_maxLevelBarrier];
+				int iValue = upgrade.maxLevel + iChange;
+				int iMaxLevelBarrier = upgrade.maxLevelBarrier;
 				if(iValue > 0 && (iMaxLevelBarrier <= 0 || iValue <= iMaxLevelBarrier || g_hCVIgnoreLevelBarrier.BoolValue))
 				{
-					upgrade[UPGR_maxLevelConvar].SetInt(iValue);
-					LogAction(param1, -1, "%L changed maxlevel of upgrade %s temporarily from %d to %d.", param1, upgrade[UPGR_name], upgrade[UPGR_maxLevel], iValue);
+					upgrade.maxLevelConvar.SetInt(iValue);
+					LogAction(param1, -1, "%L changed maxlevel of upgrade %s temporarily from %d to %d.", param1, upgrade.name, upgrade.maxLevel, iValue);
 				}
 			}
 			case ChangeProp_Cost:
 			{
-				int iValue = upgrade[UPGR_startCost] + iChange;
+				int iValue = upgrade.startCost + iChange;
 				if(iValue >= 0)
 				{
-					upgrade[UPGR_startCostConvar].SetInt(iValue);
-					LogAction(param1, -1, "%L changed start costs of upgrade %s temporarily from %d to %d.", param1, upgrade[UPGR_name], upgrade[UPGR_startCost], iValue);
+					upgrade.startCostConvar.SetInt(iValue);
+					LogAction(param1, -1, "%L changed start costs of upgrade %s temporarily from %d to %d.", param1, upgrade.name, upgrade.startCost, iValue);
 				}
 			}
 			case ChangeProp_Icost:
 			{
-				int iValue = upgrade[UPGR_incCost] + iChange;
+				int iValue = upgrade.incCost + iChange;
 				if(iValue > 0)
 				{
-					upgrade[UPGR_incCostConvar].SetInt(iValue);
-					LogAction(param1, -1, "%L changed increasing costs of upgrade %s temporarily from %d to %d.", param1, upgrade[UPGR_name], upgrade[UPGR_incCost], iValue);
+					upgrade.incCostConvar.SetInt(iValue);
+					LogAction(param1, -1, "%L changed increasing costs of upgrade %s temporarily from %d to %d.", param1, upgrade.name, upgrade.incCost, iValue);
 				}
 			}
 		}

--- a/scripting/smrpg/smrpg_menu.sp
+++ b/scripting/smrpg/smrpg_menu.sp
@@ -49,31 +49,31 @@ void InitMenu()
 {
 	// Add any already loaded upgrades to the menus
 	int iSize = GetUpgradeCount();
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	char sBuffer[MAX_UPGRADE_SHORTNAME_LENGTH+20];
 	for(int i=0;i<iSize;i++)
 	{
 		GetUpgradeByIndex(i, upgrade);
 		
-		if(upgrade[UPGR_topmenuUpgrades] == INVALID_TOPMENUOBJECT)
+		if(upgrade.topmenuUpgrades == INVALID_TOPMENUOBJECT)
 		{
-			Format(sBuffer, sizeof(sBuffer), "rpgupgrade_%s", upgrade[UPGR_shortName]);
-			upgrade[UPGR_topmenuUpgrades] = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleUpgrades, g_TopMenuUpgrades);
+			Format(sBuffer, sizeof(sBuffer), "rpgupgrade_%s", upgrade.shortName);
+			upgrade.topmenuUpgrades = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleUpgrades, g_TopMenuUpgrades);
 		}
-		if(upgrade[UPGR_topmenuSell] == INVALID_TOPMENUOBJECT)
+		if(upgrade.topmenuSell == INVALID_TOPMENUOBJECT)
 		{
-			Format(sBuffer, sizeof(sBuffer), "rpgsell_%s", upgrade[UPGR_shortName]);
-			upgrade[UPGR_topmenuSell] = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleSell, g_TopMenuSell);
+			Format(sBuffer, sizeof(sBuffer), "rpgsell_%s", upgrade.shortName);
+			upgrade.topmenuSell = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleSell, g_TopMenuSell);
 		}
-		if(upgrade[UPGR_topmenuUpgradeSettings] == INVALID_TOPMENUOBJECT)
+		if(upgrade.topmenuUpgradeSettings == INVALID_TOPMENUOBJECT)
 		{
-			Format(sBuffer, sizeof(sBuffer), "rpgupgrsettings_%s", upgrade[UPGR_shortName]);
-			upgrade[UPGR_topmenuUpgradeSettings] = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleUpgradeSettings, g_TopMenuUpgradeSettings);
+			Format(sBuffer, sizeof(sBuffer), "rpgupgrsettings_%s", upgrade.shortName);
+			upgrade.topmenuUpgradeSettings = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleUpgradeSettings, g_TopMenuUpgradeSettings);
 		}
-		if(upgrade[UPGR_topmenuHelp] == INVALID_TOPMENUOBJECT)
+		if(upgrade.topmenuHelp == INVALID_TOPMENUOBJECT)
 		{
-			Format(sBuffer, sizeof(sBuffer), "rpghelp_%s", upgrade[UPGR_shortName]);
-			upgrade[UPGR_topmenuHelp] = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleHelp, g_TopMenuHelp);
+			Format(sBuffer, sizeof(sBuffer), "rpghelp_%s", upgrade.shortName);
+			upgrade.topmenuHelp = g_hRPGTopMenu.AddItem(sBuffer, TopMenu_HandleHelp, g_TopMenuHelp);
 		}
 		SaveUpgradeConfig(upgrade);
 	}
@@ -186,38 +186,38 @@ public void TopMenu_HandleUpgrades(TopMenu topmenu, TopMenuAction action, TopMen
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			if(!GetUpgradeByShortname(sShortname[11], upgrade))
 				return;
 			
-			if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+			if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 				return;
 			
 			// Show the team this upgrade is locked to, if it is.
 			char sTeamlock[128];
-			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade[UPGR_teamlock] < GetTeamCount())
+			if((!IsClientInLockedTeam(param, upgrade) || upgrade.teamlock > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade.teamlock < GetTeamCount())
 			{
-				GetTeamName(upgrade[UPGR_teamlock], sTeamlock, sizeof(sTeamlock));
+				GetTeamName(upgrade.teamlock, sTeamlock, sizeof(sTeamlock));
 				Format(sTeamlock, sizeof(sTeamlock), " (%T)", "Is teamlocked", param, sTeamlock);
 			}
 			
 			char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+			GetUpgradeTranslatedName(param, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 			
-			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade.index);
 			
-			if(iCurrentLevel >= upgrade[UPGR_maxLevel])
+			if(iCurrentLevel >= upgrade.maxLevel)
 			{
 				Format(buffer, maxlength, "%T", "RPG menu buy upgrade entry max level", param, sTranslatedName, iCurrentLevel, "Cost", sTeamlock);
 			}
 			// Optionally show the maxlevel of the upgrade
 			else if (g_hCVShowMaxLevelInMenu.BoolValue)
 			{
-				Format(buffer, maxlength, "%T", "RPG menu buy upgrade entry show max", param, sTranslatedName, iCurrentLevel+1, upgrade[UPGR_maxLevel], "Cost", GetUpgradeCost(upgrade[UPGR_index], iCurrentLevel+1), sTeamlock);
+				Format(buffer, maxlength, "%T", "RPG menu buy upgrade entry show max", param, sTranslatedName, iCurrentLevel+1, upgrade.maxLevel, "Cost", GetUpgradeCost(upgrade.index, iCurrentLevel+1), sTeamlock);
 			}
 			else
 			{
-				Format(buffer, maxlength, "%T", "RPG menu buy upgrade entry", param, sTranslatedName, iCurrentLevel+1, "Cost", GetUpgradeCost(upgrade[UPGR_index], iCurrentLevel+1), sTeamlock);
+				Format(buffer, maxlength, "%T", "RPG menu buy upgrade entry", param, sTranslatedName, iCurrentLevel+1, "Cost", GetUpgradeCost(upgrade.index, iCurrentLevel+1), sTeamlock);
 			}
 		}
 		case TopMenuAction_DrawOption:
@@ -225,15 +225,15 @@ public void TopMenu_HandleUpgrades(TopMenu topmenu, TopMenuAction action, TopMen
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			// Don't show invalid upgrades at all in the menu.
-			if(!GetUpgradeByShortname(sShortname[11], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled] || !HasAccessToUpgrade(param, upgrade))
+			if(!GetUpgradeByShortname(sShortname[11], upgrade) || !IsValidUpgrade(upgrade) || !upgrade.enabled || !HasAccessToUpgrade(param, upgrade))
 			{
 				buffer[0] = ITEMDRAW_IGNORE;
 				return;
 			}
 			
-			int iLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iLevel = GetClientPurchasedUpgradeLevel(param, upgrade.index);
 			// The upgrade is teamlocked and the client is in the wrong team.
 			if(!IsClientInLockedTeam(param, upgrade))
 			{
@@ -241,7 +241,7 @@ public void TopMenu_HandleUpgrades(TopMenu topmenu, TopMenuAction action, TopMen
 			}
 			
 			// Don't let players buy upgrades they already maxed out.
-			if(iLevel >= upgrade[UPGR_maxLevel])
+			if(iLevel >= upgrade.maxLevel)
 				buffer[0] |= ITEMDRAW_DISABLED;
 		}
 		case TopMenuAction_SelectOption:
@@ -249,23 +249,23 @@ public void TopMenu_HandleUpgrades(TopMenu topmenu, TopMenuAction action, TopMen
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			
 			// Bad upgrade?
-			if(!GetUpgradeByShortname(sShortname[11], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled] || !HasAccessToUpgrade(param, upgrade))
+			if(!GetUpgradeByShortname(sShortname[11], upgrade) || !IsValidUpgrade(upgrade) || !upgrade.enabled || !HasAccessToUpgrade(param, upgrade))
 			{
 				g_hRPGTopMenu.Display(param, TopMenuPosition_LastCategory);
 				return;
 			}
 			
-			int iItemIndex = upgrade[UPGR_index];
+			int iItemIndex = upgrade.index;
 			int iItemLevel = GetClientPurchasedUpgradeLevel(param, iItemIndex);
 			int iCost = GetUpgradeCost(iItemIndex, iItemLevel+1);
 			
 			char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+			GetUpgradeTranslatedName(param, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 			
-			if(iItemLevel >= upgrade[UPGR_maxLevel])
+			if(iItemLevel >= upgrade.maxLevel)
 				Client_PrintToChat(param, false, "%t", "Maximum level reached");
 			else if(GetClientCredits(param) < iCost)
 				Client_PrintToChat(param, false, "%t", "Not enough credits", sTranslatedName, iItemLevel+1, iCost);
@@ -280,7 +280,7 @@ public void TopMenu_HandleUpgrades(TopMenu topmenu, TopMenuAction action, TopMen
 						{
 							if(i != param && IsClientInGame(i) && !IsFakeClient(i))
 							{
-								GetUpgradeTranslatedName(i, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+								GetUpgradeTranslatedName(i, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 								Client_PrintToChat(i, false, "%t", "Upgrade purchase notification", param, sTranslatedName, iItemLevel+1);
 							}
 						}
@@ -302,7 +302,7 @@ public void TopMenu_HandleSell(TopMenu topmenu, TopMenuAction action, TopMenuObj
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH+20];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			if(!GetUpgradeByShortname(sShortname[8], upgrade))
 				return;
 			
@@ -311,28 +311,28 @@ public void TopMenu_HandleSell(TopMenu topmenu, TopMenuAction action, TopMenuObj
 
 			// Don't show the upgrade if it is disabled and players are not allowed to sell disabled upgrades.
 			// TODO: Show if upgrade is disabled?
-			if(!upgrade[UPGR_enabled] && (!g_hCVAllowSellDisabled.BoolValue || GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]) <= 0))
+			if(!upgrade.enabled && (!g_hCVAllowSellDisabled.BoolValue || GetClientPurchasedUpgradeLevel(param, upgrade.index) <= 0))
 				return;
 			
 			// Show the team this upgrade is locked to, if it is.
 			char sTeamlock[128];
-			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade[UPGR_teamlock] < GetTeamCount())
+			if((!IsClientInLockedTeam(param, upgrade) || upgrade.teamlock > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade.teamlock < GetTeamCount())
 			{
-				GetTeamName(upgrade[UPGR_teamlock], sTeamlock, sizeof(sTeamlock));
+				GetTeamName(upgrade.teamlock, sTeamlock, sizeof(sTeamlock));
 				Format(sTeamlock, sizeof(sTeamlock), " (%T)", "Is teamlocked", param, sTeamlock);
 			}
 			
 			char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+			GetUpgradeTranslatedName(param, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 			
 			// Optionally show the maxlevel of the upgrade
 			if (g_hCVShowMaxLevelInMenu.BoolValue)
 			{
-				Format(buffer, maxlength, "%T", "RPG menu sell upgrade entry show max", param, sTranslatedName, GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]), upgrade[UPGR_maxLevel], "Sale", GetUpgradeSale(upgrade[UPGR_index], GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index])), sTeamlock);
+				Format(buffer, maxlength, "%T", "RPG menu sell upgrade entry show max", param, sTranslatedName, GetClientPurchasedUpgradeLevel(param, upgrade.index), upgrade.maxLevel, "Sale", GetUpgradeSale(upgrade.index, GetClientPurchasedUpgradeLevel(param, upgrade.index)), sTeamlock);
 			}
 			else
 			{
-				Format(buffer, maxlength, "%T", "RPG menu sell upgrade entry", param, sTranslatedName, GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]), "Sale", GetUpgradeSale(upgrade[UPGR_index], GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index])), sTeamlock);
+				Format(buffer, maxlength, "%T", "RPG menu sell upgrade entry", param, sTranslatedName, GetClientPurchasedUpgradeLevel(param, upgrade.index), "Sale", GetUpgradeSale(upgrade.index, GetClientPurchasedUpgradeLevel(param, upgrade.index)), sTeamlock);
 			}
 		}
 		case TopMenuAction_DrawOption:
@@ -340,7 +340,7 @@ public void TopMenu_HandleSell(TopMenu topmenu, TopMenuAction action, TopMenuObj
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			// Don't show invalid upgrades at all in the menu.
 			if(!GetUpgradeByShortname(sShortname[8], upgrade) || !IsValidUpgrade(upgrade))
 			{
@@ -348,9 +348,9 @@ public void TopMenu_HandleSell(TopMenu topmenu, TopMenuAction action, TopMenuObj
 				return;
 			}
 
-			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade.index);
 			// Don't show the upgrade if it is disabled and players are not allowed to sell disabled upgrades.
-			if(!upgrade[UPGR_enabled] && (!g_hCVAllowSellDisabled.BoolValue || iCurrentLevel <= 0))
+			if(!upgrade.enabled && (!g_hCVAllowSellDisabled.BoolValue || iCurrentLevel <= 0))
 				return;
 			
 			// Allow clients to sell upgrades they no longer have access to, but don't show them, if they never bought it.
@@ -375,7 +375,7 @@ public void TopMenu_HandleSell(TopMenu topmenu, TopMenuAction action, TopMenuObj
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			
 			// Bad upgrade?
 			if(!GetUpgradeByShortname(sShortname[8], upgrade) || !IsValidUpgrade(upgrade))
@@ -385,7 +385,7 @@ public void TopMenu_HandleSell(TopMenu topmenu, TopMenuAction action, TopMenuObj
 			}
 
 			// Don't allow selling the upgrade if it is disabled and players are not allowed to sell disabled upgrades.
-			if(!upgrade[UPGR_enabled] && (!g_hCVAllowSellDisabled.BoolValue || GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]) <= 0))
+			if(!upgrade.enabled && (!g_hCVAllowSellDisabled.BoolValue || GetClientPurchasedUpgradeLevel(param, upgrade.index) <= 0))
 				return;
 			
 			Menu hMenu = new Menu(Menu_ConfirmSell, MENU_ACTIONS_DEFAULT|MenuAction_Display|MenuAction_DisplayItem);
@@ -394,7 +394,7 @@ public void TopMenu_HandleSell(TopMenu topmenu, TopMenuAction action, TopMenuObj
 			hMenu.SetTitle("credits_display");
 			
 			char sIndex[10];
-			IntToString(upgrade[UPGR_index], sIndex, sizeof(sIndex));
+			IntToString(upgrade.index, sIndex, sizeof(sIndex));
 			hMenu.AddItem(sIndex, "Yes");
 			hMenu.AddItem("no", "No");
 			
@@ -414,10 +414,10 @@ public int Menu_ConfirmSell(Menu menu, MenuAction action, int param1, int param2
 			return 0;
 		
 		int iItemIndex = StringToInt(sInfo);
-		int upgrade[InternalUpgradeInfo];
+		InternalUpgradeInfo upgrade;
 		GetUpgradeByIndex(iItemIndex, upgrade);
 		char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-		GetUpgradeTranslatedName(param1, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+		GetUpgradeTranslatedName(param1, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 		
 		if (SellClientUpgrade(param1, iItemIndex))
 			Client_PrintToChat(param1, false, "%t", "Upgrade sold", sTranslatedName, GetClientPurchasedUpgradeLevel(param1, iItemIndex));
@@ -469,32 +469,32 @@ public void TopMenu_HandleUpgradeSettings(TopMenu topmenu, TopMenuAction action,
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			if(!GetUpgradeByShortname(sShortname[16], upgrade))
 				return;
 			
-			if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+			if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 				return;
 			
 			// Show the team this upgrade is locked to, if it is.
 			char sTeamlock[128];
-			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade[UPGR_teamlock] < GetTeamCount())
+			if((!IsClientInLockedTeam(param, upgrade) || upgrade.teamlock > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade.teamlock < GetTeamCount())
 			{
-				GetTeamName(upgrade[UPGR_teamlock], sTeamlock, sizeof(sTeamlock));
+				GetTeamName(upgrade.teamlock, sTeamlock, sizeof(sTeamlock));
 				Format(sTeamlock, sizeof(sTeamlock), " (%T)", "Is teamlocked", param, sTeamlock);
 			}
 			
-			int iPurchasedLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
-			int iSelectedLevel = GetClientSelectedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iPurchasedLevel = GetClientPurchasedUpgradeLevel(param, upgrade.index);
+			int iSelectedLevel = GetClientSelectedUpgradeLevel(param, upgrade.index);
 			
 			char sTranslatedName[MAX_UPGRADE_NAME_LENGTH];
-			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+			GetUpgradeTranslatedName(param, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 			
 			char sBuffer[128];
 			if(!g_hCVDisableLevelSelection.BoolValue)
-				Format(sBuffer, sizeof(sBuffer), "%T", "RPG menu upgrade settings entry level selection", param, sTranslatedName, iSelectedLevel, iPurchasedLevel, IsClientUpgradeEnabled(param, upgrade[UPGR_index])?"On":"Off", sTeamlock);
+				Format(sBuffer, sizeof(sBuffer), "%T", "RPG menu upgrade settings entry level selection", param, sTranslatedName, iSelectedLevel, iPurchasedLevel, IsClientUpgradeEnabled(param, upgrade.index)?"On":"Off", sTeamlock);
 			else
-				Format(sBuffer, sizeof(sBuffer), "%T", "RPG menu upgrade settings entry", param, sTranslatedName, iSelectedLevel, IsClientUpgradeEnabled(param, upgrade[UPGR_index])?"On":"Off", sTeamlock);
+				Format(sBuffer, sizeof(sBuffer), "%T", "RPG menu upgrade settings entry", param, sTranslatedName, iSelectedLevel, IsClientUpgradeEnabled(param, upgrade.index)?"On":"Off", sTeamlock);
 			strcopy(buffer, maxlength, sBuffer);
 		}
 		case TopMenuAction_DrawOption:
@@ -502,15 +502,15 @@ public void TopMenu_HandleUpgradeSettings(TopMenu topmenu, TopMenuAction action,
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			// Don't show invalid upgrades at all in the menu.
-			if(!GetUpgradeByShortname(sShortname[16], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+			if(!GetUpgradeByShortname(sShortname[16], upgrade) || !IsValidUpgrade(upgrade) || !upgrade.enabled)
 			{
 				buffer[0] = ITEMDRAW_IGNORE;
 				return;
 			}
 			
-			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade.index);
 			
 			// Allow clients to view upgrades they no longer have access to, but don't show them, if they never bought it.
 			if(!HasAccessToUpgrade(param, upgrade) && iCurrentLevel <= 0)
@@ -532,16 +532,16 @@ public void TopMenu_HandleUpgradeSettings(TopMenu topmenu, TopMenuAction action,
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			
 			// Bad upgrade?
-			if(!GetUpgradeByShortname(sShortname[16], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+			if(!GetUpgradeByShortname(sShortname[16], upgrade) || !IsValidUpgrade(upgrade) || !upgrade.enabled)
 			{
 				g_hRPGTopMenu.Display(param, TopMenuPosition_LastCategory);
 				return;
 			}
 			
-			DisplayUpgradeSettingsMenu(param, upgrade[UPGR_index]);
+			DisplayUpgradeSettingsMenu(param, upgrade.index);
 		}
 	}
 }
@@ -555,40 +555,40 @@ void DisplayUpgradeSettingsMenu(int client, int iUpgradeIndex)
 	GetUpgradeTranslatedName(client, iUpgradeIndex, sTranslatedName, sizeof(sTranslatedName));
 	hMenu.SetTitle("%T\n-----\n%s\n", "Credits", client, GetClientCredits(client), sTranslatedName);
 	
-	int playerupgrade[PlayerUpgradeInfo];
+	PlayerUpgradeInfo playerupgrade;
 	GetPlayerUpgradeInfoByIndex(client, iUpgradeIndex, playerupgrade);
 	
 	char sBuffer[64];
-	Format(sBuffer, sizeof(sBuffer), "%T: %T", "Enabled", client, playerupgrade[PUI_enabled]?"On":"Off", client);
+	Format(sBuffer, sizeof(sBuffer), "%T: %T", "Enabled", client, playerupgrade.enabled?"On":"Off", client);
 	hMenu.AddItem("enable", sBuffer);
 	
 	if(!g_hCVDisableLevelSelection.BoolValue)
 	{
-		Format(sBuffer, sizeof(sBuffer), "%T: %d/%d", "Selected level", client, playerupgrade[PUI_selectedlevel], playerupgrade[PUI_purchasedlevel]);
+		Format(sBuffer, sizeof(sBuffer), "%T: %d/%d", "Selected level", client, playerupgrade.selectedlevel, playerupgrade.purchasedlevel);
 		hMenu.AddItem("", sBuffer, ITEMDRAW_DISABLED);
 		Format(sBuffer, sizeof(sBuffer), "%T", "Increase selected level", client);
-		hMenu.AddItem("incselect", sBuffer, playerupgrade[PUI_selectedlevel]<playerupgrade[PUI_purchasedlevel]?ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
+		hMenu.AddItem("incselect", sBuffer, playerupgrade.selectedlevel<playerupgrade.purchasedlevel?ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
 		Format(sBuffer, sizeof(sBuffer), "%T", "Decrease selected level", client);
-		hMenu.AddItem("decselect", sBuffer, playerupgrade[PUI_selectedlevel]>0?ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
+		hMenu.AddItem("decselect", sBuffer, playerupgrade.selectedlevel>0?ITEMDRAW_DEFAULT:ITEMDRAW_DISABLED);
 	}
 	
-	int upgrade[InternalUpgradeInfo];
+	InternalUpgradeInfo upgrade;
 	GetUpgradeByIndex(iUpgradeIndex, upgrade);
 	
-	bool bHasVisuals = upgrade[UPGR_visualsConvar] != null && upgrade[UPGR_enableVisuals];
-	bool bHasSounds = upgrade[UPGR_soundsConvar] != null && upgrade[UPGR_enableSounds];
+	bool bHasVisuals = upgrade.visualsConvar != null && upgrade.enableVisuals;
+	bool bHasSounds = upgrade.soundsConvar != null && upgrade.enableSounds;
 	
 	if(bHasVisuals || bHasSounds)
 	{
 		hMenu.AddItem("", "", ITEMDRAW_SPACER);
 		if(bHasVisuals)
 		{
-			Format(sBuffer, sizeof(sBuffer), "%T: %T", "Visual effects", client, playerupgrade[PUI_visuals]?"On":"Off", client);
+			Format(sBuffer, sizeof(sBuffer), "%T: %T", "Visual effects", client, playerupgrade.visuals?"On":"Off", client);
 			hMenu.AddItem("visuals", sBuffer);
 		}
 		if(bHasSounds)
 		{
-			Format(sBuffer, sizeof(sBuffer), "%T: %T", "Sound effects", client, playerupgrade[PUI_sounds]?"On":"Off", client);
+			Format(sBuffer, sizeof(sBuffer), "%T: %T", "Sound effects", client, playerupgrade.sounds?"On":"Off", client);
 			hMenu.AddItem("sounds", sBuffer);
 		}
 	}
@@ -604,31 +604,31 @@ public int Menu_HandleUpgradeSettings(Menu menu, MenuAction action, int param1, 
 		char sInfo[16];
 		menu.GetItem(param2, sInfo, sizeof(sInfo));
 		
-		int playerupgrade[PlayerUpgradeInfo];
+		PlayerUpgradeInfo playerupgrade;
 		GetPlayerUpgradeInfoByIndex(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade);
 		
 		if(StrEqual(sInfo, "enable"))
 		{
-			SetClientUpgradeEnabledStatus(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade[PUI_enabled]?false:true);
+			SetClientUpgradeEnabledStatus(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade.enabled?false:true);
 		}
 		else if(StrEqual(sInfo, "incselect"))
 		{
 			if(!g_hCVDisableLevelSelection.BoolValue)
-				SetClientSelectedUpgradeLevel(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade[PUI_selectedlevel]+1);
+				SetClientSelectedUpgradeLevel(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade.selectedlevel+1);
 		}
 		else if(StrEqual(sInfo, "decselect"))
 		{
-			if(playerupgrade[PUI_selectedlevel] > 0 && !g_hCVDisableLevelSelection.BoolValue)
-				SetClientSelectedUpgradeLevel(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade[PUI_selectedlevel]-1);
+			if(playerupgrade.selectedlevel > 0 && !g_hCVDisableLevelSelection.BoolValue)
+				SetClientSelectedUpgradeLevel(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade.selectedlevel-1);
 		}
 		else if(StrEqual(sInfo, "visuals"))
 		{
-			playerupgrade[PUI_visuals] = playerupgrade[PUI_visuals]?false:true;
+			playerupgrade.visuals = playerupgrade.visuals?false:true;
 			SavePlayerUpgradeInfo(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade);
 		}
 		else if(StrEqual(sInfo, "sounds"))
 		{
-			playerupgrade[PUI_sounds] = playerupgrade[PUI_sounds]?false:true;
+			playerupgrade.sounds = playerupgrade.sounds?false:true;
 			SavePlayerUpgradeInfo(param1, g_iSelectedSettingsUpgrade[param1], playerupgrade);
 		}
 		
@@ -834,23 +834,23 @@ public void TopMenu_HandleHelp(TopMenu topmenu, TopMenuAction action, TopMenuObj
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			if(!GetUpgradeByShortname(sShortname[8], upgrade))
 				return;
 			
-			if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+			if(!IsValidUpgrade(upgrade) || !upgrade.enabled)
 				return;
 			
 			// Show the team this upgrade is locked to, if it is.
 			char sTeamlock[128];
-			if((!IsClientInLockedTeam(param, upgrade) || upgrade[UPGR_teamlock] > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade[UPGR_teamlock] < GetTeamCount())
+			if((!IsClientInLockedTeam(param, upgrade) || upgrade.teamlock > 1 && g_hCVShowTeamlockNoticeOwnTeam.BoolValue) && upgrade.teamlock < GetTeamCount())
 			{
-				GetTeamName(upgrade[UPGR_teamlock], sTeamlock, sizeof(sTeamlock));
+				GetTeamName(upgrade.teamlock, sTeamlock, sizeof(sTeamlock));
 				Format(sTeamlock, sizeof(sTeamlock), " (%T)", "Is teamlocked", param, sTeamlock);
 			}
 			
 			char sDescription[MAX_UPGRADE_DESCRIPTION_LENGTH];
-			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sDescription, sizeof(sDescription));
+			GetUpgradeTranslatedName(param, upgrade.index, sDescription, sizeof(sDescription));
 			
 			Format(buffer, maxlength, "%s%s", sDescription, sTeamlock);
 		}
@@ -859,15 +859,15 @@ public void TopMenu_HandleHelp(TopMenu topmenu, TopMenuAction action, TopMenuObj
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			// Don't show invalid upgrades at all in the menu.
-			if(!GetUpgradeByShortname(sShortname[8], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+			if(!GetUpgradeByShortname(sShortname[8], upgrade) || !IsValidUpgrade(upgrade) || !upgrade.enabled)
 			{
 				buffer[0] = ITEMDRAW_IGNORE;
 				return;
 			}
 			
-			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade[UPGR_index]);
+			int iCurrentLevel = GetClientPurchasedUpgradeLevel(param, upgrade.index);
 			
 			// Allow clients to read help about upgrades they no longer have access to, but don't show them, if they never bought it.
 			if(!HasAccessToUpgrade(param, upgrade) && iCurrentLevel <= 0)
@@ -889,18 +889,18 @@ public void TopMenu_HandleHelp(TopMenu topmenu, TopMenuAction action, TopMenuObj
 			char sShortname[MAX_UPGRADE_SHORTNAME_LENGTH];
 			topmenu.GetObjName(object_id, sShortname, sizeof(sShortname));
 			
-			int upgrade[InternalUpgradeInfo];
+			InternalUpgradeInfo upgrade;
 			
 			// Bad upgrade?
-			if(!GetUpgradeByShortname(sShortname[8], upgrade) || !IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled])
+			if(!GetUpgradeByShortname(sShortname[8], upgrade) || !IsValidUpgrade(upgrade) || !upgrade.enabled)
 			{
 				g_hRPGTopMenu.Display(param, TopMenuPosition_LastCategory);
 				return;
 			}
 			
 			char sTranslatedName[MAX_UPGRADE_NAME_LENGTH], sTranslatedDescription[MAX_UPGRADE_DESCRIPTION_LENGTH];
-			GetUpgradeTranslatedName(param, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
-			GetUpgradeTranslatedDescription(param, upgrade[UPGR_index], sTranslatedDescription, sizeof(sTranslatedDescription));
+			GetUpgradeTranslatedName(param, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
+			GetUpgradeTranslatedDescription(param, upgrade.index, sTranslatedDescription, sizeof(sTranslatedDescription));
 			
 			Client_PrintToChat(param, false, "{OG}SM:RPG{N} > {G}%s{N}: %s", sTranslatedName, sTranslatedDescription);
 			
@@ -917,7 +917,8 @@ void DisplayOtherUpgradesMenu(int client, int targetClient)
 	hMenu.SetTitle("%N\n%T\n-----\n", targetClient, "Credits", client, GetClientCredits(targetClient));
 	
 	int iSize = GetUpgradeCount();
-	int upgrade[InternalUpgradeInfo], iCurrentLevel;
+	InternalUpgradeInfo upgrade;
+	int iCurrentLevel;
 	char sTranslatedName[MAX_UPGRADE_NAME_LENGTH], sLine[128], sIndex[8];
 	for(int i=0;i<iSize;i++)
 	{
@@ -925,19 +926,19 @@ void DisplayOtherUpgradesMenu(int client, int targetClient)
 		GetUpgradeByIndex(i, upgrade);
 		
 		// Don't show disabled items in the menu.
-		if(!IsValidUpgrade(upgrade) || !upgrade[UPGR_enabled] || !HasAccessToUpgrade(targetClient, upgrade) || !IsClientInLockedTeam(targetClient, upgrade))
+		if(!IsValidUpgrade(upgrade) || !upgrade.enabled || !HasAccessToUpgrade(targetClient, upgrade) || !IsClientInLockedTeam(targetClient, upgrade))
 			continue;
 		
-		GetUpgradeTranslatedName(client, upgrade[UPGR_index], sTranslatedName, sizeof(sTranslatedName));
+		GetUpgradeTranslatedName(client, upgrade.index, sTranslatedName, sizeof(sTranslatedName));
 		
-		if(iCurrentLevel >= upgrade[UPGR_maxLevel])
+		if(iCurrentLevel >= upgrade.maxLevel)
 		{
 			Format(sLine, sizeof(sLine), "%T", "RPG menu other players upgrades entry max level", client, sTranslatedName, iCurrentLevel);
 		}
 		// Optionally show the maxlevel of the upgrade
 		else if (g_hCVShowMaxLevelInMenu.BoolValue)
 		{
-			Format(sLine, sizeof(sLine), "%T", "RPG menu other players upgrades entry show max", client, sTranslatedName, iCurrentLevel, upgrade[UPGR_maxLevel]);
+			Format(sLine, sizeof(sLine), "%T", "RPG menu other players upgrades entry show max", client, sTranslatedName, iCurrentLevel, upgrade.maxLevel);
 		}
 		else
 		{

--- a/scripting/smrpg/smrpg_stats.sp
+++ b/scripting/smrpg/smrpg_stats.sp
@@ -10,42 +10,42 @@ int g_iNextCacheUpdate[MAXPLAYERS+1];
 int g_iCachedRankCount = 0;
 int g_iNextCacheCountUpdate;
 
-enum SessionStats {
-	SS_JoinTime,
-	SS_JoinLevel,
-	SS_JoinExperience,
-	SS_JoinCredits,
-	SS_JoinRank,
-	bool:SS_WantsAutoUpdate,
-	bool:SS_WantsMenuOpen,
-	bool:SS_OKToClose,
-	ArrayList:SS_LastExperience
-};
+enum struct SessionStats {
+	int joinTime;
+	int joinLevel;
+	int joinExperience;
+	int joinCredits;
+	int joinRank;
+	bool wantsAutoUpdate;
+	bool wantsMenuOpen;
+	bool okToClose;
+	ArrayList lastExperience;
+}
 
-int g_iPlayerSessionStartStats[MAXPLAYERS+1][SessionStats];
+SessionStats g_iPlayerSessionStartStats[MAXPLAYERS+1];
 bool g_bBackToStatsMenu[MAXPLAYERS+1];
 
 Handle g_hfwdOnAddExperience;
 Handle g_hfwdOnAddExperiencePost;
 
 // AFK Handling
-enum AFKInfo {
-	Float:AFK_lastPosition[3],
-	AFK_startTime,
-	AFK_spawnTime,
-	AFK_deathTime
+enum struct AFKInfo {
+	float lastPosition[3];
+	int startTime;
+	int spawnTime;
+	int deathTime;
 }
-int g_PlayerAFKInfo[MAXPLAYERS+1][AFKInfo];
+AFKInfo g_PlayerAFKInfo[MAXPLAYERS+1];
 bool g_bPlayerSpawnProtected[MAXPLAYERS+1];
 
 // Individual weapon experience settings
 StringMap g_hWeaponExperience;
 
-enum WeaponExperienceContainer {
-	Float:WXP_Damage,
-	Float:WXP_Kill,
-	Float:WXP_Bonus
-};
+enum struct WeaponExperienceContainer {
+	float damage;
+	float kill;
+	float bonus;
+}
 
 void RegisterStatsNatives()
 {
@@ -438,40 +438,40 @@ public Action Timer_CheckAFKPlayers(Handle timer)
 			GetClientAbsOrigin(i, fOrigin);
 			
 			// See if the player just spawned..
-			if(g_PlayerAFKInfo[i][AFK_spawnTime] > 0)
+			if(g_PlayerAFKInfo[i].spawnTime > 0)
 			{
-				int iDifference = GetTime() - g_PlayerAFKInfo[i][AFK_spawnTime];
+				int iDifference = GetTime() - g_PlayerAFKInfo[i].spawnTime;
 				// The player spawned 2 seconds ago. He's now ready to be checked for being afk again.
 				if(iDifference > 2)
 				{
-					g_PlayerAFKInfo[i][AFK_spawnTime] = 0;
-					if(g_PlayerAFKInfo[i][AFK_startTime] > 0)
-						g_PlayerAFKInfo[i][AFK_startTime] += iDifference;
-					Array_Copy(fOrigin, g_PlayerAFKInfo[i][AFK_lastPosition], 3);
+					g_PlayerAFKInfo[i].spawnTime = 0;
+					if(g_PlayerAFKInfo[i].startTime > 0)
+						g_PlayerAFKInfo[i].startTime += iDifference;
+					Array_Copy(fOrigin, g_PlayerAFKInfo[i].lastPosition, 3);
 				}
 				continue;
 			}
 			
 			// See if we need to subtract some time while he was dead.
-			if(g_PlayerAFKInfo[i][AFK_deathTime] > 0)
+			if(g_PlayerAFKInfo[i].deathTime > 0)
 			{
-				if(g_PlayerAFKInfo[i][AFK_startTime] > 0)
-					g_PlayerAFKInfo[i][AFK_startTime] += GetTime() - g_PlayerAFKInfo[i][AFK_deathTime];
-				g_PlayerAFKInfo[i][AFK_deathTime] = 0;
+				if(g_PlayerAFKInfo[i].startTime > 0)
+					g_PlayerAFKInfo[i].startTime += GetTime() - g_PlayerAFKInfo[i].deathTime;
+				g_PlayerAFKInfo[i].deathTime = 0;
 			}
 			
-			Array_Copy(g_PlayerAFKInfo[i][AFK_lastPosition], fLastPosition, 3);
+			Array_Copy(g_PlayerAFKInfo[i].lastPosition, fLastPosition, 3);
 			if(Math_VectorsEqual(fOrigin, fLastPosition, 1.0))
 			{
-				if(g_PlayerAFKInfo[i][AFK_startTime] == 0)
-					g_PlayerAFKInfo[i][AFK_startTime] = GetTime();
+				if(g_PlayerAFKInfo[i].startTime == 0)
+					g_PlayerAFKInfo[i].startTime = GetTime();
 			}
 			else
 			{
-				g_PlayerAFKInfo[i][AFK_startTime] = 0;
+				g_PlayerAFKInfo[i].startTime = 0;
 			}
 			
-			Array_Copy(fOrigin, g_PlayerAFKInfo[i][AFK_lastPosition], 3);
+			Array_Copy(fOrigin, g_PlayerAFKInfo[i].lastPosition, 3);
 		}
 	}
 	
@@ -480,24 +480,24 @@ public Action Timer_CheckAFKPlayers(Handle timer)
 
 bool IsClientAFK(int client)
 {
-	if(g_PlayerAFKInfo[client][AFK_startTime] == 0)
+	if(g_PlayerAFKInfo[client].startTime == 0)
 		return false;
 	
 	int iAFKTime = g_hCVAFKTime.IntValue;
 	if(iAFKTime <= 0)
 		return false;
 	
-	if((GetTime() - g_PlayerAFKInfo[client][AFK_startTime]) > iAFKTime)
+	if((GetTime() - g_PlayerAFKInfo[client].startTime) > iAFKTime)
 		return true;
 	return false;
 }
 
 void ResetAFKPlayer(int client)
 {
-	g_PlayerAFKInfo[client][AFK_startTime] = 0;
-	g_PlayerAFKInfo[client][AFK_spawnTime] = 0;
-	g_PlayerAFKInfo[client][AFK_deathTime] = 0;
-	Array_Copy(g_PlayerAFKInfo[client][AFK_lastPosition], view_as<float>({0.0,0.0,0.0}), 3);
+	g_PlayerAFKInfo[client].startTime = 0;
+	g_PlayerAFKInfo[client].spawnTime = 0;
+	g_PlayerAFKInfo[client].deathTime = 0;
+	Array_Copy(g_PlayerAFKInfo[client].lastPosition, view_as<float>({0.0,0.0,0.0}), 3);
 }
 
 // Spawn Protection handling
@@ -660,45 +660,45 @@ public int Native_GetWeaponExperience(Handle plugin, int numParams)
 // rpgsession handling
 void InitPlayerSessionStartStats(int client)
 {
-	g_iPlayerSessionStartStats[client][SS_JoinTime] = GetTime();
-	g_iPlayerSessionStartStats[client][SS_JoinLevel] = GetClientLevel(client);
-	g_iPlayerSessionStartStats[client][SS_JoinExperience] = GetClientExperience(client);
-	g_iPlayerSessionStartStats[client][SS_JoinCredits] = GetClientCredits(client);
-	g_iPlayerSessionStartStats[client][SS_JoinRank] = -1;
-	g_iPlayerSessionStartStats[client][SS_WantsAutoUpdate] = false;
-	g_iPlayerSessionStartStats[client][SS_WantsMenuOpen] = false;
-	g_iPlayerSessionStartStats[client][SS_OKToClose] = false;
+	g_iPlayerSessionStartStats[client].joinTime = GetTime();
+	g_iPlayerSessionStartStats[client].joinLevel = GetClientLevel(client);
+	g_iPlayerSessionStartStats[client].joinExperience = GetClientExperience(client);
+	g_iPlayerSessionStartStats[client].joinCredits = GetClientCredits(client);
+	g_iPlayerSessionStartStats[client].joinRank = -1;
+	g_iPlayerSessionStartStats[client].wantsAutoUpdate = false;
+	g_iPlayerSessionStartStats[client].wantsMenuOpen = false;
+	g_iPlayerSessionStartStats[client].okToClose = false;
 	
 	ArrayList hLastExperience = new ArrayList(ByteCountToCells(256));
 	hLastExperience.Resize(g_hCVLastExperienceCount.IntValue);
 	hLastExperience.SetString(0, "");
-	g_iPlayerSessionStartStats[client][SS_LastExperience] = hLastExperience;
+	g_iPlayerSessionStartStats[client].lastExperience = hLastExperience;
 }
 
 void ResetPlayerSessionStats(int client)
 {
-	g_iPlayerSessionStartStats[client][SS_JoinTime] = 0;
-	g_iPlayerSessionStartStats[client][SS_JoinLevel] = 0;
-	g_iPlayerSessionStartStats[client][SS_JoinExperience] = 0;
-	g_iPlayerSessionStartStats[client][SS_JoinCredits] = 0;
-	g_iPlayerSessionStartStats[client][SS_JoinRank] = -1;
-	g_iPlayerSessionStartStats[client][SS_WantsAutoUpdate] = false;
-	g_iPlayerSessionStartStats[client][SS_WantsMenuOpen] = false;
-	g_iPlayerSessionStartStats[client][SS_OKToClose] = false;
-	ClearHandle(g_iPlayerSessionStartStats[client][SS_LastExperience]);
+	g_iPlayerSessionStartStats[client].joinTime = 0;
+	g_iPlayerSessionStartStats[client].joinLevel = 0;
+	g_iPlayerSessionStartStats[client].joinExperience = 0;
+	g_iPlayerSessionStartStats[client].joinCredits = 0;
+	g_iPlayerSessionStartStats[client].joinRank = -1;
+	g_iPlayerSessionStartStats[client].wantsAutoUpdate = false;
+	g_iPlayerSessionStartStats[client].wantsMenuOpen = false;
+	g_iPlayerSessionStartStats[client].okToClose = false;
+	ClearHandle(g_iPlayerSessionStartStats[client].lastExperience);
 }
 
 // Use our own forward to initialize the session info :)
 public void SMRPG_OnClientLoaded(int client)
 {
 	// Only set it once and leave it that way until he really disconnects.
-	if(g_iPlayerSessionStartStats[client][SS_JoinTime] == 0)
+	if(g_iPlayerSessionStartStats[client].joinTime == 0)
 		InitPlayerSessionStartStats(client);
 }
 
 void InsertSessionExperienceString(int client, const char[] sExperience)
 {
-	ArrayList hLastExperience = g_iPlayerSessionStartStats[client][SS_LastExperience];
+	ArrayList hLastExperience = g_iPlayerSessionStartStats[client].lastExperience;
 	// Not loaded yet..
 	if(hLastExperience == null)
 		return;
@@ -713,8 +713,8 @@ public void ConVar_LastExperienceCountChanged(ConVar convar, const char[] oldVal
 	// Apply the new size immediately.
 	for(int i=1;i<=MaxClients;i++)
 	{
-		if(g_iPlayerSessionStartStats[i][SS_JoinTime] > 0)
-			g_iPlayerSessionStartStats[i][SS_LastExperience].Resize(convar.IntValue);
+		if(g_iPlayerSessionStartStats[i].joinTime > 0)
+			g_iPlayerSessionStartStats[i].lastExperience.Resize(convar.IntValue);
 	}
 }
 
@@ -728,7 +728,7 @@ public Action Timer_UpdateSessionMenus(Handle timer)
 	for(int i=1;i<=MaxClients;i++)
 	{
 		// Refresh the contents of the menu here.
-		if(IsClientInGame(i) && !IsFakeClient(i) && g_iPlayerSessionStartStats[i][SS_WantsMenuOpen] && g_iPlayerSessionStartStats[i][SS_WantsAutoUpdate])
+		if(IsClientInGame(i) && !IsFakeClient(i) && g_iPlayerSessionStartStats[i].wantsMenuOpen && g_iPlayerSessionStartStats[i].wantsAutoUpdate)
 			DisplaySessionStatsMenu(i);
 	}
 	
@@ -755,38 +755,38 @@ void DisplaySessionStatsMenu(int client)
 	Format(sBuffer, sizeof(sBuffer), "%T", "Session", client);
 	hPanel.DrawItem(sBuffer);
 	
-	SecondsToString(sBuffer, sizeof(sBuffer), GetTime()-g_iPlayerSessionStartStats[client][SS_JoinTime], false);
+	SecondsToString(sBuffer, sizeof(sBuffer), GetTime()-g_iPlayerSessionStartStats[client].joinTime, false);
 	Format(sBuffer, sizeof(sBuffer), "  %T", "Playtime", client, sBuffer);
 	hPanel.DrawText(sBuffer);
 	
-	int iChangedLevels = GetClientLevel(client) - g_iPlayerSessionStartStats[client][SS_JoinLevel];
+	int iChangedLevels = GetClientLevel(client) - g_iPlayerSessionStartStats[client].joinLevel;
 	Format(sBuffer, sizeof(sBuffer), "  %T: %s%d", "Changed level", client, iChangedLevels>0?"+":"", iChangedLevels);
 	hPanel.DrawText(sBuffer);
 	
 	// Need to calculate the total earned experience.
-	int iEarnedExperience = GetClientExperience(client) - g_iPlayerSessionStartStats[client][SS_JoinExperience];
+	int iEarnedExperience = GetClientExperience(client) - g_iPlayerSessionStartStats[client].joinExperience;
 	for(int i=0;i<iChangedLevels;i++)
 	{
-		iEarnedExperience += Stats_LvlToExp(g_iPlayerSessionStartStats[client][SS_JoinLevel]+i);
+		iEarnedExperience += Stats_LvlToExp(g_iPlayerSessionStartStats[client].joinLevel+i);
 	}
 	
 	Format(sBuffer, sizeof(sBuffer), "  %T: %s%d", "Changed experience", client, iEarnedExperience>0?"+":"", iEarnedExperience);
 	hPanel.DrawText(sBuffer);
 	
-	int iBuffer = GetClientCredits(client) - g_iPlayerSessionStartStats[client][SS_JoinCredits];
+	int iBuffer = GetClientCredits(client) - g_iPlayerSessionStartStats[client].joinCredits;
 	Format(sBuffer, sizeof(sBuffer), "  %T: %s%d", "Changed credits", client, iBuffer>0?"+":"", iBuffer);
 	hPanel.DrawText(sBuffer);
 	
-	if(g_iPlayerSessionStartStats[client][SS_JoinRank] != -1)
+	if(g_iPlayerSessionStartStats[client].joinRank != -1)
 	{
-		iBuffer = g_iPlayerSessionStartStats[client][SS_JoinRank] - GetClientRank(client);
+		iBuffer = g_iPlayerSessionStartStats[client].joinRank - GetClientRank(client);
 		Format(sBuffer, sizeof(sBuffer), "  %T: %s%d", "Changed rank", client, iBuffer>0?"+":"", iBuffer);
 		hPanel.DrawText(sBuffer);
 	}
 	
 	hPanel.DrawItem("", ITEMDRAW_SPACER);
 	
-	Format(sBuffer, sizeof(sBuffer), "%T: %T", "Auto refresh panel", client, (g_iPlayerSessionStartStats[client][SS_WantsAutoUpdate]?"Yes":"No"), client);
+	Format(sBuffer, sizeof(sBuffer), "%T: %T", "Auto refresh panel", client, (g_iPlayerSessionStartStats[client].wantsAutoUpdate?"Yes":"No"), client);
 	hPanel.DrawItem(sBuffer);
 	
 	Format(sBuffer, sizeof(sBuffer), "%T", "Last Experience", client);
@@ -798,9 +798,9 @@ void DisplaySessionStatsMenu(int client)
 	// If the old menu is currently displaying (callback was not called yet) we don't want it to stay closed when we display it again.
 	// So we set OKToClose to true, so it doesn't set WantsMenuOpen to false as if the menu was closed by an interrupting menu.
 	// That way the menu stays open and is refreshed every second while staying closed if the player closes it or some other menu is displayed over it.
-	if(g_iPlayerSessionStartStats[client][SS_WantsMenuOpen])
-		g_iPlayerSessionStartStats[client][SS_OKToClose] = true;
-	g_iPlayerSessionStartStats[client][SS_WantsMenuOpen] = true;
+	if(g_iPlayerSessionStartStats[client].wantsMenuOpen)
+		g_iPlayerSessionStartStats[client].okToClose = true;
+	g_iPlayerSessionStartStats[client].wantsMenuOpen = true;
 	
 	hPanel.Send(client, Panel_HandleSessionMenu, MENU_TIME_FOREVER);
 	delete hPanel;
@@ -810,13 +810,13 @@ public int Panel_HandleSessionMenu(Menu menu, MenuAction action, int param1, int
 {
 	if(action == MenuAction_Select)
 	{
-		g_iPlayerSessionStartStats[param1][SS_WantsMenuOpen] = false;
-		g_iPlayerSessionStartStats[param1][SS_OKToClose] = false;
+		g_iPlayerSessionStartStats[param1].wantsMenuOpen = false;
+		g_iPlayerSessionStartStats[param1].okToClose = false;
 		
 		// Toggle the auto update
 		if(param2 == 4)
 		{
-			g_iPlayerSessionStartStats[param1][SS_WantsAutoUpdate] = !g_iPlayerSessionStartStats[param1][SS_WantsAutoUpdate];
+			g_iPlayerSessionStartStats[param1].wantsAutoUpdate = !g_iPlayerSessionStartStats[param1].wantsAutoUpdate;
 			DisplaySessionStatsMenu(param1);
 			return;
 		}
@@ -828,15 +828,15 @@ public int Panel_HandleSessionMenu(Menu menu, MenuAction action, int param1, int
 	else if(action == MenuAction_Cancel)
 	{
 		
-		if(!g_iPlayerSessionStartStats[param1][SS_OKToClose])
-			g_iPlayerSessionStartStats[param1][SS_WantsMenuOpen] = false;
-		g_iPlayerSessionStartStats[param1][SS_OKToClose] = false;
+		if(!g_iPlayerSessionStartStats[param1].okToClose)
+			g_iPlayerSessionStartStats[param1].wantsMenuOpen = false;
+		g_iPlayerSessionStartStats[param1].okToClose = false;
 	}
 }
 
 void DisplaySessionLastExperienceMenu(int client, bool bBackToStatsMenu)
 {
-	ArrayList hLastExperience = g_iPlayerSessionStartStats[client][SS_LastExperience];
+	ArrayList hLastExperience = g_iPlayerSessionStartStats[client].lastExperience;
 	// Player not loaded yet.
 	if(hLastExperience == null)
 		return;
@@ -932,8 +932,8 @@ public void SQL_GetClientRank(Database db, DBResultSet results, const char[] err
 	g_iCachedRank[client] = results.FetchInt(0) + 1; // +1 since the query returns the count, not the rank
 	
 	// Save the first time we fetch the rank for him.
-	if(g_iPlayerSessionStartStats[client][SS_JoinRank] == -1)
-		g_iPlayerSessionStartStats[client][SS_JoinRank] = g_iCachedRank[client];
+	if(g_iPlayerSessionStartStats[client].joinRank == -1)
+		g_iPlayerSessionStartStats[client].joinRank = g_iCachedRank[client];
 }
 
 void UpdateRankCount()
@@ -972,13 +972,13 @@ public void SQL_GetRankCount(Database db, DBResultSet results, const char[] erro
 	
 	g_iCachedRankCount = results.FetchInt(0);
 	
-	int info[PlayerInfo];
+	PlayerInfo info;
 	for(int i=1;i<=MaxClients;i++)
 	{
 		if(IsClientInGame(i) && !IsFakeClient(i))
 		{
 			GetClientRPGInfo(i, info);
-			if(info[PLR_dbId] < 0)
+			if(info.dbId < 0)
 				g_iCachedRankCount++; /* accounts for players not saved in the db */
 		}
 	}
@@ -1184,16 +1184,16 @@ bool ReadWeaponExperienceConfig()
 	}
 	
 	char sWeapon[64];
-	int iWeaponExperience[WeaponExperienceContainer];
+	WeaponExperienceContainer weaponExperience;
 	do {
 		hKV.GetSectionName(sWeapon, sizeof(sWeapon));
 		RemovePrefixFromString("weapon_", sWeapon, sWeapon, sizeof(sWeapon));
 	
-		iWeaponExperience[WXP_Damage] = hKV.GetFloat("exp_damage", -1.0);
-		iWeaponExperience[WXP_Kill] = hKV.GetFloat("exp_kill", -1.0);
-		iWeaponExperience[WXP_Bonus] = hKV.GetFloat("exp_bonus", -1.0);
+		weaponExperience.damage = hKV.GetFloat("exp_damage", -1.0);
+		weaponExperience.kill = hKV.GetFloat("exp_kill", -1.0);
+		weaponExperience.bonus = hKV.GetFloat("exp_bonus", -1.0);
 		
-		g_hWeaponExperience.SetArray(sWeapon, iWeaponExperience[0], view_as<int>(WeaponExperienceContainer));
+		g_hWeaponExperience.SetArray(sWeapon, weaponExperience, sizeof(WeaponExperienceContainer));
 		
 	} while(hKV.GotoNextKey());
 	
@@ -1203,25 +1203,36 @@ bool ReadWeaponExperienceConfig()
 
 float GetWeaponExperience(const char[] sWeapon, WeaponExperienceType type)
 {
-	int iWeaponExperience[WeaponExperienceContainer];
-	iWeaponExperience[WXP_Damage] = -1.0;
-	iWeaponExperience[WXP_Kill] = -1.0;
-	iWeaponExperience[WXP_Bonus] = -1.0;
+	WeaponExperienceContainer weaponExperience;
+	weaponExperience.damage = -1.0;
+	weaponExperience.kill = -1.0;
+	weaponExperience.bonus = -1.0;
 	
 	char sBuffer[64];
 	RemovePrefixFromString("weapon_", sWeapon, sBuffer, sizeof(sBuffer));
 	// We default back to the convar values, if this fails.
-	g_hWeaponExperience.GetArray(sBuffer, iWeaponExperience[0], view_as<int>(WeaponExperienceContainer));
+	g_hWeaponExperience.GetArray(sBuffer, weaponExperience, sizeof(WeaponExperienceContainer));
 	
 	// Fall back to default convar values, if unset or invalid.
-	if(iWeaponExperience[WXP_Damage] < 0.0)
-		iWeaponExperience[WXP_Damage] = g_hCVExpDamage.FloatValue;
-	if(iWeaponExperience[WXP_Kill] < 0.0)
-		iWeaponExperience[WXP_Kill] = g_hCVExpKill.FloatValue;
-	if(iWeaponExperience[WXP_Bonus] < 0.0)
-		iWeaponExperience[WXP_Bonus] = g_hCVExpKillBonus.FloatValue;
+	if(weaponExperience.damage < 0.0)
+		weaponExperience.damage = g_hCVExpDamage.FloatValue;
+	if(weaponExperience.kill < 0.0)
+		weaponExperience.kill = g_hCVExpKill.FloatValue;
+	if(weaponExperience.bonus < 0.0)
+		weaponExperience.bonus = g_hCVExpKillBonus.FloatValue;
 	
-	return view_as<float>(iWeaponExperience[type]);
+	switch(WeaponExperience_Damage)
+	{
+		case WeaponExperience_Damage:
+			return weaponExperience.damage;
+		case WeaponExperience_Kill:
+			return weaponExperience.kill;
+		case WeaponExperience_Bonus:
+			return weaponExperience.bonus;
+		default:
+			ThrowError("Unknown WeaponExperienceType: %d", type);
+	}
+	return 0.0;
 }
 
 /**

--- a/scripting/smrpg_effects/laggedmovement.sp
+++ b/scripting/smrpg_effects/laggedmovement.sp
@@ -7,15 +7,15 @@ Handle g_hfwdOnClientLaggedMovementChange;
 Handle g_hfwdOnClientLaggedMovementChanged;
 Handle g_hfwdOnClientLaggedMovementReset;
 
-enum MovementState {
-	Float:MS_default,
-	Float:MS_slower,
-	Float:MS_faster,
-	Handle:MS_lastSlowPlugin,
-	Handle:MS_lastFastPlugin
-};
+enum struct MovementState {
+	float base;
+	float slower;
+	float faster;
+	Handle lastSlowPlugin;
+	Handle lastFastPlugin;
+}
 
-int g_ClientMovementState[MAXPLAYERS+1][MovementState];
+MovementState g_ClientMovementState[MAXPLAYERS+1];
 Handle g_hSlowRestoreTimer[MAXPLAYERS+1];
 Handle g_hFastRestoreTimer[MAXPLAYERS+1];
 
@@ -44,11 +44,11 @@ void ResetLaggedMovementClient(int client, bool bDisconnect)
 {
 	if(IsClientInGame(client))
 	{
-		if(g_ClientMovementState[client][MS_faster] > 0.0)
+		if(g_ClientMovementState[client].faster > 0.0)
 			ResetSpeedUp(client);
-		if(g_ClientMovementState[client][MS_slower] > 0.0)
+		if(g_ClientMovementState[client].slower > 0.0)
 			ResetSlowDown(client);
-		if(g_ClientMovementState[client][MS_default] != 1.0)
+		if(g_ClientMovementState[client].base != 1.0)
 		{
 			if(bDisconnect)
 				ResetDefaultSpeed(client);
@@ -60,11 +60,11 @@ void ResetLaggedMovementClient(int client, bool bDisconnect)
 	delete g_hSlowRestoreTimer[client];
 	
 	if(bDisconnect)
-		g_ClientMovementState[client][MS_default] = 1.0;
-	g_ClientMovementState[client][MS_slower] = 0.0;
-	g_ClientMovementState[client][MS_faster] = 0.0;
-	g_ClientMovementState[client][MS_lastSlowPlugin] = null;
-	g_ClientMovementState[client][MS_lastFastPlugin] = null;
+		g_ClientMovementState[client].base = 1.0;
+	g_ClientMovementState[client].slower = 0.0;
+	g_ClientMovementState[client].faster = 0.0;
+	g_ClientMovementState[client].lastSlowPlugin = null;
+	g_ClientMovementState[client].lastFastPlugin = null;
 }
 
 /**
@@ -138,15 +138,15 @@ public int Native_ChangeClientLaggedMovement(Handle plugin, int numParams)
 			return false;
 		
 		// Already slower? Ignore this effect.
-		if(g_ClientMovementState[client][MS_slower] >= fSlowdown)
+		if(g_ClientMovementState[client].slower >= fSlowdown)
 			return false;
 		
 		// Are you insane?
 		if(fTime <= 0.0)
 			return ThrowNativeError(SP_ERROR_NATIVE, "Invalid effect time %f.", fTime);
 		
-		g_ClientMovementState[client][MS_slower] = fSlowdown;
-		g_ClientMovementState[client][MS_lastSlowPlugin] = plugin;
+		g_ClientMovementState[client].slower = fSlowdown;
+		g_ClientMovementState[client].lastSlowPlugin = plugin;
 		
 		// Do the correct new speed.
 		ApplyLaggedMovementValue(client);
@@ -178,15 +178,15 @@ public int Native_ChangeClientLaggedMovement(Handle plugin, int numParams)
 			return false;
 		
 		// Already faster? Ignore this effect.
-		if(g_ClientMovementState[client][MS_faster] >= fSpeedup)
+		if(g_ClientMovementState[client].faster >= fSpeedup)
 			return false;
 		
 		// Are you insane?
 		if(fTime <= 0.0)
 			return ThrowNativeError(SP_ERROR_NATIVE, "Invalid effect time %f.", fTime);
 		
-		g_ClientMovementState[client][MS_faster] = fSpeedup;
-		g_ClientMovementState[client][MS_lastFastPlugin] = plugin;
+		g_ClientMovementState[client].faster = fSpeedup;
+		g_ClientMovementState[client].lastFastPlugin = plugin;
 		
 		// Do the correct new speed.
 		ApplyLaggedMovementValue(client);
@@ -222,11 +222,11 @@ public int Native_ResetClientLaggedMovement(Handle plugin, int numParams)
 		case LMT_Slower:
 		{
 			// Player is not slowed down?
-			if(g_ClientMovementState[client][MS_slower] == 0.0)
+			if(g_ClientMovementState[client].slower == 0.0)
 				return false;
 			
 			// Slowed down by some other plugin.
-			if(g_ClientMovementState[client][MS_lastSlowPlugin] != plugin && !bForce)
+			if(g_ClientMovementState[client].lastSlowPlugin != plugin && !bForce)
 				return false;
 			
 			// Reset the speed.
@@ -235,11 +235,11 @@ public int Native_ResetClientLaggedMovement(Handle plugin, int numParams)
 		case LMT_Faster:
 		{
 			// Player is not sped up?
-			if(g_ClientMovementState[client][MS_faster] == 0.0)
+			if(g_ClientMovementState[client].faster == 0.0)
 				return false;
 			
 			// Sped up by some other plugin.
-			if(g_ClientMovementState[client][MS_lastFastPlugin] != plugin && !bForce)
+			if(g_ClientMovementState[client].lastFastPlugin != plugin && !bForce)
 				return false;
 			
 			// Reset the speed.
@@ -247,7 +247,7 @@ public int Native_ResetClientLaggedMovement(Handle plugin, int numParams)
 		}
 		case LMT_Default:
 		{
-			if (g_ClientMovementState[client][MS_default] == 1.0)
+			if (g_ClientMovementState[client].base == 1.0)
 				return false;
 			ResetDefaultSpeed(client);
 		}
@@ -276,26 +276,26 @@ public int Native_IsClientLaggedMovementChanged(Handle plugin, int numParams)
 		case LMT_Slower:
 		{
 			// Player is not slowed down?
-			if(g_ClientMovementState[client][MS_slower] == 0.0)
+			if(g_ClientMovementState[client].slower == 0.0)
 				return false;
 			
 			// Slowed down by some other plugin.
-			if(g_ClientMovementState[client][MS_lastSlowPlugin] != plugin && bByMe)
+			if(g_ClientMovementState[client].lastSlowPlugin != plugin && bByMe)
 				return false;
 		}
 		case LMT_Faster:
 		{
 			// Player is not sped up?
-			if(g_ClientMovementState[client][MS_faster] == 0.0)
+			if(g_ClientMovementState[client].faster == 0.0)
 				return false;
 			
 			// Sped up by some other plugin.
-			if(g_ClientMovementState[client][MS_lastFastPlugin] != plugin && bByMe)
+			if(g_ClientMovementState[client].lastFastPlugin != plugin && bByMe)
 				return false;
 		}
 		case LMT_Default:
 		{
-			if(g_ClientMovementState[client][MS_default] == 1.0)
+			if(g_ClientMovementState[client].base == 1.0)
 				return false;
 		}
 		default:
@@ -331,7 +331,7 @@ public int Native_SetClientDefaultLaggedMovement(Handle plugin, int numParams)
 	if(ret >= Plugin_Handled)
 		return false;
 
-	g_ClientMovementState[client][MS_default] = fValue;
+	g_ClientMovementState[client].base = fValue;
 	ApplyLaggedMovementValue(client);
 
 	// Inform that the speed was changed.
@@ -352,18 +352,18 @@ stock void ApplyLaggedMovementValue(int client)
 	if(!IsClientInGame(client))
 		return;
 
-	float fSlow = g_ClientMovementState[client][MS_slower];
-	float fFast = g_ClientMovementState[client][MS_faster];
+	float fSlow = g_ClientMovementState[client].slower;
+	float fFast = g_ClientMovementState[client].faster;
 	
-	float fValue = (g_ClientMovementState[client][MS_default] - fSlow) + fFast;
+	float fValue = (g_ClientMovementState[client].base - fSlow) + fFast;
 	SetEntPropFloat(client, Prop_Send, "m_flLaggedMovementValue", fValue);
 }
 
 void ResetSlowDown(int client)
 {
 	// Reset the effect
-	g_ClientMovementState[client][MS_slower] = 0.0;
-	g_ClientMovementState[client][MS_lastSlowPlugin] = null;
+	g_ClientMovementState[client].slower = 0.0;
+	g_ClientMovementState[client].lastSlowPlugin = null;
 	delete g_hSlowRestoreTimer[client];
 	
 	ApplyLaggedMovementValue(client);
@@ -377,8 +377,8 @@ void ResetSlowDown(int client)
 void ResetSpeedUp(int client)
 {
 	// Reset the effect
-	g_ClientMovementState[client][MS_faster] = 0.0;
-	g_ClientMovementState[client][MS_lastFastPlugin] = null;
+	g_ClientMovementState[client].faster = 0.0;
+	g_ClientMovementState[client].lastFastPlugin = null;
 	delete g_hFastRestoreTimer[client];
 	
 	ApplyLaggedMovementValue(client);
@@ -391,7 +391,7 @@ void ResetSpeedUp(int client)
 
 void ResetDefaultSpeed(int client)
 {
-	g_ClientMovementState[client][MS_default] = 1.0;
+	g_ClientMovementState[client].base = 1.0;
 	
 	ApplyLaggedMovementValue(client);
 	

--- a/scripting/upgrades/smrpg_upgrade_adrenaline.sp
+++ b/scripting/upgrades/smrpg_upgrade_adrenaline.sp
@@ -166,9 +166,7 @@ void ApplyAdrenalineEffect(int client)
 		return;
 
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_antidote.sp
+++ b/scripting/upgrades/smrpg_upgrade_antidote.sp
@@ -132,9 +132,7 @@ float GetClientEffectReduction(int client)
 		return 0.0;
 	
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return 0.0;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_antiflash_cstrike.sp
+++ b/scripting/upgrades/smrpg_upgrade_antiflash_cstrike.sp
@@ -97,9 +97,7 @@ public void Event_OnPlayerBlind(Event event, const char[] name, bool dontBroadca
 		return;
 	
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_armorhelmet_cstrike.sp
+++ b/scripting/upgrades/smrpg_upgrade_armorhelmet_cstrike.sp
@@ -81,9 +81,7 @@ public void Event_OnPlayerSpawn(Event event, const char[] name, bool dontBroadca
 		return;
 	
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_armorplus_cstrike.sp
+++ b/scripting/upgrades/smrpg_upgrade_armorplus_cstrike.sp
@@ -122,9 +122,6 @@ public void SMRPG_BuySell(int client, UpgradeQueryType type)
 	if(IsFakeClient(client) && SMRPG_IgnoreBots())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	
 	int iArmor = GetClientArmor(client);
 	int iMaxArmor = GetClientMaxArmor(client);
 	
@@ -167,9 +164,7 @@ int GetClientMaxArmor(int client)
 	if(!SMRPG_IsEnabled())
 		return iDefaultMaxArmor;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return iDefaultMaxArmor;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_armorregen_cstrike.sp
+++ b/scripting/upgrades/smrpg_upgrade_armorregen_cstrike.sp
@@ -112,9 +112,7 @@ public Action Timer_IncreaseArmor(Handle timer, any userid)
 	if(!SMRPG_IsEnabled())
 		return Plugin_Continue;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return Plugin_Continue;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_bouncybullets.sp
+++ b/scripting/upgrades/smrpg_upgrade_bouncybullets.sp
@@ -128,9 +128,7 @@ public void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float
 		return;
 	
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_clipsize.sp
+++ b/scripting/upgrades/smrpg_upgrade_clipsize.sp
@@ -220,9 +220,9 @@ public void Hook_OnWeaponDropPost(int client, int weapon)
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
+	UpgradeInfo upgrade;
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!upgrade.enabled)
 		return;
 	
 	// Restore the original game's default maxclip1, if the weapon currently has more ammo loaded.
@@ -278,9 +278,7 @@ public Action Hook_OnReload(int weapon)
 	if(!SMRPG_IsEnabled())
 		return Plugin_Continue;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return Plugin_Continue;
 	
 	// Are bots allowed to use this upgrade?
@@ -333,9 +331,7 @@ public void Hook_OnReloadPost(int weapon, bool bSuccessful)
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?
@@ -632,9 +628,7 @@ bool IsUpgradeActive(int client)
 	if(!SMRPG_IsEnabled())
 		return false;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return false;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_damage.sp
+++ b/scripting/upgrades/smrpg_upgrade_damage.sp
@@ -11,10 +11,10 @@
 ConVar g_hCVDefaultPercent;
 ConVar g_hCVDefaultMaxDamage;
 
-enum WeaponConfig {
-	Float:Weapon_DamageInc,
-	Float:Weapon_MaxIncrease
-};
+enum struct WeaponConfig {
+	float damageInc;
+	float maxIncrease;
+}
 
 StringMap g_hWeaponDamage;
 
@@ -102,9 +102,7 @@ public Action Hook_OnTakeDamage(int victim, int &attacker, int &inflictor, float
 	if(!SMRPG_IsEnabled())
 		return Plugin_Continue;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return Plugin_Continue;
 	
 	// Are bots allowed to use this upgrade?
@@ -171,15 +169,15 @@ bool LoadWeaponConfig()
 	char sWeapon[64];
 	if(hKV.GotoFirstSubKey(false))
 	{
-		int eInfo[WeaponConfig];
+		WeaponConfig info;
 		do
 		{
 			hKV.GetSectionName(sWeapon, sizeof(sWeapon));
 			
-			eInfo[Weapon_DamageInc] = hKV.GetFloat("dmg_increase", -1.0);
-			eInfo[Weapon_MaxIncrease] = hKV.GetFloat("max_additional_dmg", -1.0);
+			info.damageInc = hKV.GetFloat("dmg_increase", -1.0);
+			info.maxIncrease = hKV.GetFloat("max_additional_dmg", -1.0);
 			
-			g_hWeaponDamage.SetArray(sWeapon, eInfo[0], view_as<int>(WeaponConfig));
+			g_hWeaponDamage.SetArray(sWeapon, info, sizeof(WeaponConfig));
 			
 		} while (hKV.GotoNextKey());
 	}
@@ -190,11 +188,11 @@ bool LoadWeaponConfig()
 
 float GetWeaponDamageIncreasePercent(const char[] sWeapon)
 {
-	int eInfo[WeaponConfig];
-	if (g_hWeaponDamage.GetArray(sWeapon, eInfo[0], view_as<int>(WeaponConfig)))
+	WeaponConfig info;
+	if (g_hWeaponDamage.GetArray(sWeapon, info, sizeof(WeaponConfig)))
 	{
-		if (eInfo[Weapon_DamageInc] >= 0.0)
-			return eInfo[Weapon_DamageInc];
+		if (info.damageInc >= 0.0)
+			return info.damageInc;
 	}
 	
 	// Just use the default value
@@ -203,11 +201,11 @@ float GetWeaponDamageIncreasePercent(const char[] sWeapon)
 
 float GetWeaponMaxAdditionalDamage(const char[] sWeapon)
 {
-	int eInfo[WeaponConfig];
-	if (g_hWeaponDamage.GetArray(sWeapon, eInfo[0], view_as<int>(WeaponConfig)))
+	WeaponConfig info;
+	if (g_hWeaponDamage.GetArray(sWeapon, info, sizeof(WeaponConfig)))
 	{
-		if (eInfo[Weapon_MaxIncrease] >= 0.0)
-			return eInfo[Weapon_MaxIncrease];
+		if (info.maxIncrease >= 0.0)
+			return info.maxIncrease;
 	}
 	
 	// Just use the default value

--- a/scripting/upgrades/smrpg_upgrade_denial.sp
+++ b/scripting/upgrades/smrpg_upgrade_denial.sp
@@ -84,11 +84,8 @@ public void Event_OnPlayerSpawn(Event event, const char[] name, bool dontBroadca
 	if(!client)
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	
 	/* Reset player Denial data while Denial is disabled */
-	if(!SMRPG_IsEnabled() || !upgrade[UI_enabled])
+	if(!SMRPG_IsEnabled() || !SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 	{
 		Denial_ResetClient(client);
 		return;
@@ -114,11 +111,8 @@ public void Event_OnPlayerDeath(Event event, const char[] name, bool dontBroadca
 	if(!client)
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	
 	/* Reset player Denial data while Denial is disabled */
-	if(!SMRPG_IsEnabled() || !upgrade[UI_enabled])
+	if(!SMRPG_IsEnabled() || !SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 	{
 		Denial_ResetClient(client);
 		return;
@@ -164,11 +158,8 @@ public void SMRPG_TranslateUpgrade(int client, const char[] shortname, Translati
  */
 public Action Hook_WeaponEquipPost(int client, int weapon)
 {
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	
 	/* Reset player Denial data while Denial is disabled */
-	if(!SMRPG_IsEnabled() || !upgrade[UI_enabled])
+	if(!SMRPG_IsEnabled() || !SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 	{
 		Denial_ResetClient(client);
 		return Plugin_Continue;

--- a/scripting/upgrades/smrpg_upgrade_example.sp
+++ b/scripting/upgrades/smrpg_upgrade_example.sp
@@ -144,9 +144,7 @@ void ApplyMyUpgradeEffect(int client)
 		return;
 	
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_falldamage.sp
+++ b/scripting/upgrades/smrpg_upgrade_falldamage.sp
@@ -100,9 +100,7 @@ public Action Hook_OnTakeDamage(int victim, int &attacker, int &inflictor, float
 		return Plugin_Continue;
 	
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return Plugin_Continue;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_fastreload_cstrike.sp
+++ b/scripting/upgrades/smrpg_upgrade_fastreload_cstrike.sp
@@ -118,9 +118,7 @@ void IncreaseReloadSpeed(int client)
 		return;
 	
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?
@@ -304,9 +302,7 @@ public void Hook_OnReloadPost(int weapon, bool bSuccessful)
 		return;
 	
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_firepistol.sp
+++ b/scripting/upgrades/smrpg_upgrade_firepistol.sp
@@ -103,9 +103,7 @@ public void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// This player is already burning. Don't stack the effect and wait until he stopped to be able to burn him again.

--- a/scripting/upgrades/smrpg_upgrade_firerate.sp
+++ b/scripting/upgrades/smrpg_upgrade_firerate.sp
@@ -108,9 +108,7 @@ public void Hook_OnPostThink(int client)
 			return;
 
 		// The upgrade is disabled completely?
-		int upgrade[UpgradeInfo];
-		SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-		if(!upgrade[UI_enabled])
+		if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 			return;
 
 		// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_fnade.sp
+++ b/scripting/upgrades/smrpg_upgrade_fnade.sp
@@ -124,9 +124,7 @@ public void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_fpistol.sp
+++ b/scripting/upgrades/smrpg_upgrade_fpistol.sp
@@ -159,9 +159,7 @@ public void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_gravity.sp
+++ b/scripting/upgrades/smrpg_upgrade_gravity.sp
@@ -181,9 +181,7 @@ void ApplyGravity(int client, bool bIgnoreNullLevel = false)
 		return;
 	
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?
@@ -212,8 +210,7 @@ void ApplyGravity(int client, bool bIgnoreNullLevel = false)
 // Also make sure it's reset, when the upgrade is disabled.
 stock void CheckGravity(bool bForceDisable)
 {
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
+	bool bEnabled = SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME);
 	
 	for(int i=1;i<=MaxClients;i++)
 	{
@@ -221,7 +218,7 @@ stock void CheckGravity(bool bForceDisable)
 			continue;
 		
 		// We got disabled? :(
-		if(bForceDisable || !upgrade[UI_enabled])
+		if(bForceDisable || !bEnabled)
 		{
 			// Are bots allowed to use this upgrade?
 			if(IsFakeClient(i) && SMRPG_IgnoreBots())

--- a/scripting/upgrades/smrpg_upgrade_health.sp
+++ b/scripting/upgrades/smrpg_upgrade_health.sp
@@ -71,9 +71,7 @@ public void Event_OnPlayerSpawn(Event event, const char[] name, bool dontBroadca
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?
@@ -160,9 +158,7 @@ int GetClientMaxHealth(int client)
 	if(!SMRPG_IsEnabled())
 		return iDefaultMaxHealth;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return iDefaultMaxHealth;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_icenade.sp
+++ b/scripting/upgrades/smrpg_upgrade_icenade.sp
@@ -134,9 +134,7 @@ public void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_icestab.sp
+++ b/scripting/upgrades/smrpg_upgrade_icestab.sp
@@ -123,9 +123,7 @@ public void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_impulse.sp
+++ b/scripting/upgrades/smrpg_upgrade_impulse.sp
@@ -19,11 +19,11 @@ ConVar g_hCVRequireGround;
 
 StringMap g_hWeaponConfig;
 
-enum WeaponConfig
+enum struct WeaponConfig
 {
-	Float:Config_SpeedIncrease,
-	Float:Config_Duration
-};
+	float speedIncrease;
+	float duration;
+}
 
 int g_iImpulseTrailSprites[MAXPLAYERS+1] = {-1,...};
 
@@ -165,9 +165,7 @@ public void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float
 	if(!SMRPG_IsEnabled())
 		return;
 
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 
 	// Are bots allowed to use this upgrade?
@@ -264,17 +262,18 @@ bool LoadWeaponConfig()
 	}
 
 	char sWeapon[64];
-	int config[WeaponConfig];
+	WeaponConfig config;
 	if(hKV.GotoFirstSubKey(false))
 	{
 		do
 		{
 			hKV.GetSectionName(sWeapon, sizeof(sWeapon));
-			config[Config_SpeedIncrease] = hKV.GetFloat("speed_increase", -1.0);
-			config[Config_Duration] = hKV.GetFloat("duration", -1.0);
 
-			g_hWeaponConfig.SetArray(sWeapon, config[0], view_as<int>(WeaponConfig));
-
+			config.speedIncrease = hKV.GetFloat("speed_increase", -1.0);
+			config.duration = hKV.GetFloat("duration", -1.0);
+			
+			g_hWeaponConfig.SetArray(sWeapon, config, sizeof(WeaponConfig));
+			
 		} while (hKV.GotoNextKey());
 	}
 	delete hKV;
@@ -284,11 +283,11 @@ bool LoadWeaponConfig()
 float GetWeaponSpeedIncrease(const char[] sWeapon)
 {
 	// See if there is a value for this weapon in the config.
-	int config[WeaponConfig];
-	if (g_hWeaponConfig.GetArray(sWeapon, config[0], view_as<int>(WeaponConfig)))
+	WeaponConfig config;
+	if (g_hWeaponConfig.GetArray(sWeapon, config, sizeof(WeaponConfig)))
 	{
-		if (config[Config_SpeedIncrease] >= 0.0)
-			return config[Config_SpeedIncrease];
+		if (config.speedIncrease >= 0.0)
+			return config.speedIncrease;
 	}
 
 	// Just use the default value
@@ -298,11 +297,11 @@ float GetWeaponSpeedIncrease(const char[] sWeapon)
 float GetWeaponEffectDuration(const char[] sWeapon)
 {
 	// See if there is a value for this weapon in the config.
-	int config[WeaponConfig];
-	if (g_hWeaponConfig.GetArray(sWeapon, config[0], view_as<int>(WeaponConfig)))
+	WeaponConfig config;
+	if (g_hWeaponConfig.GetArray(sWeapon, config, sizeof(WeaponConfig)))
 	{
-		if (config[Config_Duration] >= 0.0)
-			return config[Config_Duration];
+		if (config.duration >= 0.0)
+			return config.duration;
 	}
 
 	// Just use the default value

--- a/scripting/upgrades/smrpg_upgrade_ljump.sp
+++ b/scripting/upgrades/smrpg_upgrade_ljump.sp
@@ -161,9 +161,7 @@ void LJump_HasJumped(int client, float vVelocity[3])
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_medic.sp
+++ b/scripting/upgrades/smrpg_upgrade_medic.sp
@@ -116,9 +116,7 @@ public Action Timer_ApplyMedic(Handle timer, any data)
 	if(SMRPG_IsFFAEnabled())
 		return Plugin_Continue;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return Plugin_Continue;
 	
 	bool bIgnoreBots = SMRPG_IgnoreBots();

--- a/scripting/upgrades/smrpg_upgrade_mirrordmg.sp
+++ b/scripting/upgrades/smrpg_upgrade_mirrordmg.sp
@@ -107,9 +107,7 @@ void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage
 		return;
 	
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_positionswap.sp
+++ b/scripting/upgrades/smrpg_upgrade_positionswap.sp
@@ -103,9 +103,7 @@ void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float damage
 		return;
 	
 	// The upgrade is disabled completely?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_regen.sp
+++ b/scripting/upgrades/smrpg_upgrade_regen.sp
@@ -100,9 +100,7 @@ public Action Timer_IncreaseHealth(Handle timer, any userid)
 	if(!SMRPG_IsEnabled())
 		return Plugin_Continue;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return Plugin_Continue;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_resup.sp
+++ b/scripting/upgrades/smrpg_upgrade_resup.sp
@@ -128,9 +128,7 @@ public Action Timer_Resupply(Handle timer)
 	if(!SMRPG_IsEnabled())
 		return Plugin_Continue;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return Plugin_Continue;
 	
 	bool bIgnoreBots = SMRPG_IgnoreBots();

--- a/scripting/upgrades/smrpg_upgrade_shrinking.sp
+++ b/scripting/upgrades/smrpg_upgrade_shrinking.sp
@@ -103,9 +103,7 @@ void Resize_ApplyUpgrade(int client, bool bIgnoreNullLevel = false)
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?

--- a/scripting/upgrades/smrpg_upgrade_speed.sp
+++ b/scripting/upgrades/smrpg_upgrade_speed.sp
@@ -171,9 +171,7 @@ float GetClientSpeedIncrease(int client)
 		return 0.0;
 	
 	// Upgrade enabled?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return 0.0;
 	
 	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);

--- a/scripting/upgrades/smrpg_upgrade_stealth.sp
+++ b/scripting/upgrades/smrpg_upgrade_stealth.sp
@@ -94,9 +94,7 @@ public void ConVar_OnDisableImmunityAlphaChanged(ConVar convar, const char[] old
 		if(!SMRPG_IsEnabled())
 			return;
 	
-		int upgrade[UpgradeInfo];
-		SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-		if(!upgrade[UI_enabled])
+		if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 			return;
 		
 		convar.SetBool(true);
@@ -115,9 +113,7 @@ public void SMRPG_OnEnableStatusChanged(bool bEnabled)
 		return;
 
 	// Upgrade enabled too?
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// alpha change was ignored. OBEY!
@@ -139,9 +135,7 @@ public void SMRPG_OnUpgradeSettingsChanged(const char[] shortname)
 	if(!StrEqual(shortname, UPGRADE_SHORTNAME))
 		return;
 
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 
 	if(!g_hCVIgnoreImmunity.BoolValue)
@@ -162,9 +156,7 @@ public void Event_OnPlayerSpawn(Event event, const char[] name, bool dontBroadca
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?
@@ -185,9 +177,7 @@ public void Hook_OnWeaponDropPost(int client, int weapon)
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Render dropped weapons visible again!
@@ -240,9 +230,7 @@ void SetVisibilities()
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	bool bIgnoreBots = SMRPG_IgnoreBots();
@@ -277,7 +265,7 @@ void SetClientVisibility(int client)
 	
 	int iLevel = SMRPG_GetClientUpgradeLevel(client, UPGRADE_SHORTNAME);
 	
-	int upgrade[UpgradeInfo];
+	UpgradeInfo upgrade;
 	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
 	
 	// Keep the minimum alpha in byte range
@@ -286,7 +274,7 @@ void SetClientVisibility(int client)
 		iMinimumAlpha = 120;
 	
 	// Each step brings the player's visibility more towards the minimum alpha.
-	int iStepSize = (255 - iMinimumAlpha) / upgrade[UI_maxLevel];
+	int iStepSize = (255 - iMinimumAlpha) / upgrade.maxLevel;
 	
 	// Render the player more invisible each level
 	int iAlpha = 255 - iLevel * iStepSize;

--- a/scripting/upgrades/smrpg_upgrade_vampire.sp
+++ b/scripting/upgrades/smrpg_upgrade_vampire.sp
@@ -106,9 +106,7 @@ public void Hook_OnTakeDamagePost(int victim, int attacker, int inflictor, float
 	if(!SMRPG_IsEnabled())
 		return;
 	
-	int upgrade[UpgradeInfo];
-	SMRPG_GetUpgradeInfo(UPGRADE_SHORTNAME, upgrade);
-	if(!upgrade[UI_enabled])
+	if(!SMRPG_IsUpgradeEnabled(UPGRADE_SHORTNAME))
 		return;
 	
 	// Are bots allowed to use this upgrade?


### PR DESCRIPTION
This means we're now requiring SourcePawn 1.10+ to compile. SourceMod 1.10 has been stable for some time now, so not being able to load them on SourceMod 1.9 or prior seems reasonable in favor of cleaner code.